### PR TITLE
Support breaking changes of API 1.4 and Camunda 7.24

### DIFF
--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/correlation/CorrelationApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/correlation/CorrelationApiImpl.kt
@@ -10,7 +10,6 @@ import dev.bpmcrafters.processengineapi.correlation.CorrelationApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.RuntimeService
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 
@@ -25,7 +24,7 @@ class CorrelationApiImpl(
     const val USE_GLOBAL_CORRELATION_KEY = "useGlobalCorrelationKey"
   }
 
-  override fun correlateMessage(cmd: CorrelateMessageCmd): Future<Empty> {
+  override fun correlateMessage(cmd: CorrelateMessageCmd): CompletableFuture<Empty> {
     return CompletableFuture.supplyAsync {
       val correlation = cmd.correlation.get()
       val globalCorrelation = cmd.restrictions.containsKey(USE_GLOBAL_CORRELATION_KEY)

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/correlation/SignalApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/correlation/SignalApiImpl.kt
@@ -10,7 +10,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.RuntimeService
 import org.camunda.bpm.engine.runtime.SignalEventReceivedBuilder
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 
@@ -21,7 +20,7 @@ class SignalApiImpl(
   private val runtimeService: RuntimeService
 ) : SignalApi {
 
-  override fun sendSignal(cmd: SendSignalCmd): Future<Empty> {
+  override fun sendSignal(cmd: SendSignalCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-002: sending signal ${cmd.signalName}." }
     return CompletableFuture.supplyAsync {
       runtimeService
@@ -44,13 +43,19 @@ class SignalApiImpl(
       .forEach { (key, value) ->
         when (key) {
           CommonRestrictions.TENANT_ID -> this.tenantId(value).apply {
-            require(restrictions.containsKey(CommonRestrictions.WITHOUT_TENANT_ID)) { "Illegal restriction combination. ${CommonRestrictions.WITHOUT_TENANT_ID} " +
-              "and ${CommonRestrictions.WITHOUT_TENANT_ID} can't be provided in the same time because they are mutually exclusive." }
+            require(restrictions.containsKey(CommonRestrictions.WITHOUT_TENANT_ID)) {
+              "Illegal restriction combination. ${CommonRestrictions.WITHOUT_TENANT_ID} " +
+                "and ${CommonRestrictions.WITHOUT_TENANT_ID} can't be provided in the same time because they are mutually exclusive."
+            }
           }
+
           CommonRestrictions.WITHOUT_TENANT_ID -> this.withoutTenantId().apply {
-            require(restrictions.containsKey(CommonRestrictions.TENANT_ID)) { "Illegal restriction combination. ${CommonRestrictions.WITHOUT_TENANT_ID} " +
-              "and ${CommonRestrictions.WITHOUT_TENANT_ID} can't be provided in the same time because they are mutually exclusive." }
+            require(restrictions.containsKey(CommonRestrictions.TENANT_ID)) {
+              "Illegal restriction combination. ${CommonRestrictions.WITHOUT_TENANT_ID} " +
+                "and ${CommonRestrictions.WITHOUT_TENANT_ID} can't be provided in the same time because they are mutually exclusive."
+            }
           }
+
           CommonRestrictions.EXECUTION_ID -> this.executionId(value)
         }
       }

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/deploy/DeploymentApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/deploy/DeploymentApiImpl.kt
@@ -9,7 +9,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.repository.Deployment
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 
@@ -20,7 +19,7 @@ class DeploymentApiImpl(
   private val repositoryService: RepositoryService
 ) : DeploymentApi {
 
-  override fun deploy(cmd: DeployBundleCommand): Future<DeploymentInformation> {
+  override fun deploy(cmd: DeployBundleCommand): CompletableFuture<DeploymentInformation> {
     require(cmd.resources.isNotEmpty()) { "Resources must not be empty, at least one resource must be provided." }
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-003: executing a bundle deployment with ${cmd.resources.size} resources." }
     return CompletableFuture.supplyAsync {

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImpl.kt
@@ -10,7 +10,6 @@ import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.RuntimeService
 import org.camunda.bpm.engine.runtime.ProcessInstance
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 
@@ -22,7 +21,7 @@ class StartProcessApiImpl(
   private val repositoryService: RepositoryService,
 ) : StartProcessApi {
 
-  override fun startProcess(cmd: StartProcessCommand): Future<ProcessInformation> {
+  override fun startProcess(cmd: StartProcessCommand): CompletableFuture<ProcessInformation> {
     return when (cmd) {
       is StartProcessByDefinitionCmd ->
         CompletableFuture.supplyAsync {

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/C7ServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/C7ServiceTaskCompletionApiImpl.kt
@@ -6,7 +6,6 @@ import dev.bpmcrafters.processengineapi.task.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.ExternalTaskService
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 
@@ -14,13 +13,13 @@ private val logger = KotlinLogging.logger {}
  * Strategy for completing external tasks using Camunda externalTaskService Java API.
  */
 class C7ServiceTaskCompletionApiImpl(
-    private val workerId: String,
-    private val externalTaskService: ExternalTaskService,
-    private val subscriptionRepository: SubscriptionRepository,
-    private val failureRetrySupplier: FailureRetrySupplier
+  private val workerId: String,
+  private val externalTaskService: ExternalTaskService,
+  private val subscriptionRepository: SubscriptionRepository,
+  private val failureRetrySupplier: FailureRetrySupplier
 ) : ServiceTaskCompletionApi {
 
-  override fun completeTask(cmd: CompleteTaskCmd): Future<Empty> {
+  override fun completeTask(cmd: CompleteTaskCmd): CompletableFuture<Empty> {
 
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-006: completing service task ${cmd.taskId}." }
     externalTaskService.complete(
@@ -35,7 +34,7 @@ class C7ServiceTaskCompletionApiImpl(
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): Future<Empty> {
+  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-008: throwing error ${cmd.errorCode} in service task ${cmd.taskId}." }
     externalTaskService.handleBpmnError(
       cmd.taskId,
@@ -51,7 +50,7 @@ class C7ServiceTaskCompletionApiImpl(
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun failTask(cmd: FailTaskCmd): Future<Empty> {
+  override fun failTask(cmd: FailTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-010: failing service task ${cmd.taskId}." }
     val (retries, retryTimeoutInSeconds) = failureRetrySupplier.apply(cmd.taskId)
     externalTaskService.handleFailure(

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/C7UserTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/C7UserTaskCompletionApiImpl.kt
@@ -9,7 +9,6 @@ import dev.bpmcrafters.processengineapi.task.UserTaskCompletionApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.TaskService
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 
@@ -22,7 +21,7 @@ class C7UserTaskCompletionApiImpl(
   private val subscriptionRepository: SubscriptionRepository
 ) : UserTaskCompletionApi {
 
-  override fun completeTask(cmd: CompleteTaskCmd): Future<Empty> {
+  override fun completeTask(cmd: CompleteTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-011: completing user task ${cmd.taskId}." }
     taskService.complete(
       cmd.taskId,
@@ -35,7 +34,7 @@ class C7UserTaskCompletionApiImpl(
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): Future<Empty> {
+  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-013: throwing error on user task ${cmd.taskId}." }
     taskService.handleBpmnError(
       cmd.taskId,

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/modification/C7UserTaskModificationApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/modification/C7UserTaskModificationApiImpl.kt
@@ -17,7 +17,7 @@ private val logger = KotlinLogging.logger {}
 class C7UserTaskModificationApiImpl(
   private val taskService: TaskService,
 ) : UserTaskModificationApi {
-  override fun update(cmd: ModifyTaskCmd): Future<Empty> {
+  override fun update(cmd: ModifyTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-051: modifying user task ${cmd.taskId}." }
     if (cmd is CompositeModifyTaskCmd) {
       cmd.commands.forEach {

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/correlation/CorrelationApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/correlation/CorrelationApiImpl.kt
@@ -25,7 +25,7 @@ class CorrelationApiImpl(
     const val USE_GLOBAL_CORRELATION_KEY = "useGlobalCorrelationKey"
   }
 
-  override fun correlateMessage(cmd: CorrelateMessageCmd): Future<Empty> {
+  override fun correlateMessage(cmd: CorrelateMessageCmd): CompletableFuture<Empty> {
     return CompletableFuture.supplyAsync {
       val correlation = cmd.correlation.get()
       val globalCorrelation = cmd.restrictions.containsKey(USE_GLOBAL_CORRELATION_KEY)

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/correlation/SignalApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/correlation/SignalApiImpl.kt
@@ -20,7 +20,7 @@ class SignalApiImpl(
   private val valueMapper: ValueMapper
 ) : SignalApi {
 
-  override fun sendSignal(cmd: SendSignalCmd): Future<Empty> {
+  override fun sendSignal(cmd: SendSignalCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-002: Sending signal ${cmd.signalName}." }
     return CompletableFuture.supplyAsync {
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/deploy/DeploymentApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/deploy/DeploymentApiImpl.kt
@@ -17,7 +17,7 @@ class DeploymentApiImpl(
   private val deploymentApiClient: DeploymentApiClient
 ) : DeploymentApi {
 
-  override fun deploy(cmd: DeployBundleCommand): Future<DeploymentInformation> {
+  override fun deploy(cmd: DeployBundleCommand): CompletableFuture<DeploymentInformation> {
     require(cmd.resources.isNotEmpty()) { "Resources must not be empty, at least one resource must be provided." }
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-003: executing a bundle deployment with ${cmd.resources.size} resources." }
     return CompletableFuture.supplyAsync {

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImpl.kt
@@ -22,7 +22,7 @@ class StartProcessApiImpl(
   private val valueMapper: ValueMapper,
 ) : StartProcessApi {
 
-  override fun startProcess(cmd: StartProcessCommand): Future<ProcessInformation> {
+  override fun startProcess(cmd: StartProcessCommand): CompletableFuture<ProcessInformation> {
     return when (cmd) {
       is StartProcessByDefinitionCmd ->
         CompletableFuture.supplyAsync {

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImpl.kt
@@ -25,7 +25,7 @@ class FeignServiceTaskCompletionApiImpl(
   private val valueMapper: ValueMapper
 ) : ServiceTaskCompletionApi {
 
-  override fun completeTask(cmd: CompleteTaskCmd): Future<Empty> {
+  override fun completeTask(cmd: CompleteTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-006: completing service task ${cmd.taskId}." }
     externalTaskApiClient.completeExternalTaskResource(
       cmd.taskId,
@@ -42,7 +42,7 @@ class FeignServiceTaskCompletionApiImpl(
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): Future<Empty> {
+  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-008: throwing error ${cmd.errorCode} in service task ${cmd.taskId}." }
     externalTaskApiClient.handleExternalTaskBpmnError(
       cmd.taskId,
@@ -60,7 +60,7 @@ class FeignServiceTaskCompletionApiImpl(
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun failTask(cmd: FailTaskCmd): Future<Empty> {
+  override fun failTask(cmd: FailTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-010: failing service task ${cmd.taskId}." }
     val (retries, retryTimeoutInSeconds) = failureRetrySupplier.apply(cmd.taskId)
     externalTaskApiClient.handleFailure(

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/NoOpServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/NoOpServiceTaskCompletionApiImpl.kt
@@ -9,15 +9,15 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
 
 class NoOpServiceTaskCompletionApiImpl : ServiceTaskCompletionApi {
-  override fun completeTask(cmd: CompleteTaskCmd): Future<Empty> {
+  override fun completeTask(cmd: CompleteTaskCmd): CompletableFuture<Empty> {
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): Future<Empty> {
+  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): CompletableFuture<Empty> {
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun failTask(cmd: FailTaskCmd): Future<Empty> {
+  override fun failTask(cmd: FailTaskCmd): CompletableFuture<Empty> {
     return CompletableFuture.completedFuture(Empty)
   }
 }

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/NoOpUserTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/NoOpUserTaskCompletionApiImpl.kt
@@ -9,11 +9,11 @@ import java.util.concurrent.Future
 
 class NoOpUserTaskCompletionApiImpl : UserTaskCompletionApi {
 
-  override fun completeTask(cmd: CompleteTaskCmd): Future<Empty> {
+  override fun completeTask(cmd: CompleteTaskCmd): CompletableFuture<Empty> {
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): Future<Empty> {
+  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): CompletableFuture<Empty> {
     return CompletableFuture.completedFuture(Empty)
   }
 }

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImpl.kt
@@ -21,7 +21,7 @@ class OfficialClientServiceTaskCompletionApiImpl(
   private val failureRetrySupplier: FailureRetrySupplier
 ) : ServiceTaskCompletionApi {
 
-  override fun completeTask(cmd: CompleteTaskCmd): Future<Empty> {
+  override fun completeTask(cmd: CompleteTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-006: completing service task ${cmd.taskId}." }
     externalTaskService
       .complete(
@@ -38,7 +38,7 @@ class OfficialClientServiceTaskCompletionApiImpl(
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): Future<Empty> {
+  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-008: throwing error ${cmd.errorCode} in service task ${cmd.taskId}." }
     externalTaskService
       .handleBpmnError(
@@ -56,7 +56,7 @@ class OfficialClientServiceTaskCompletionApiImpl(
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun failTask(cmd: FailTaskCmd): Future<Empty> {
+  override fun failTask(cmd: FailTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-010: failing service task ${cmd.taskId}." }
     val (retries, retryTimeoutInSeconds) = failureRetrySupplier.apply(cmd.taskId)
     externalTaskService

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/UserTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/UserTaskCompletionApiImpl.kt
@@ -25,7 +25,7 @@ class UserTaskCompletionApiImpl(
   private val valueMapper: ValueMapper
 ) : UserTaskCompletionApi {
 
-  override fun completeTask(cmd: CompleteTaskCmd): Future<Empty> {
+  override fun completeTask(cmd: CompleteTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-011: completing user task ${cmd.taskId}." }
     taskApiClient.complete(
       cmd.taskId,
@@ -40,7 +40,7 @@ class UserTaskCompletionApiImpl(
     return CompletableFuture.completedFuture(Empty)
   }
 
-  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): Future<Empty> {
+  override fun completeTaskByError(cmd: CompleteTaskByErrorCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-013: throwing error on user task ${cmd.taskId}." }
     taskApiClient.handleBpmnError(
       cmd.taskId,

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/modification/UserTaskModificationApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/modification/UserTaskModificationApiImpl.kt
@@ -19,7 +19,7 @@ class UserTaskModificationApiImpl(
   private val taskApiClient: TaskApiClient,
   private val valueMapper: ValueMapper,
 ) : UserTaskModificationApi {
-  override fun update(cmd: ModifyTaskCmd): Future<Empty> {
+  override fun update(cmd: ModifyTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-051: modifying user task ${cmd.taskId}." }
     if (cmd is CompositeModifyTaskCmd) {
       cmd.commands.forEach {

--- a/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/AbstractC7RemoteApiITestBase.kt
+++ b/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/AbstractC7RemoteApiITestBase.kt
@@ -33,7 +33,7 @@ abstract class AbstractC7RemoteApiITestBase : JGivenSpringBaseIntegrationTest() 
 
     @JvmStatic
     @Container
-    val camundaContainer = Camunda7RunTestContainer("run-7.23.0")
+    val camundaContainer = Camunda7RunTestContainer("run-7.24.0")
 
     @JvmStatic
     @DynamicPropertySource

--- a/examples/java-c7-remote/docker-compose.yaml
+++ b/examples/java-c7-remote/docker-compose.yaml
@@ -1,8 +1,8 @@
 services:
 
   camunda-bpm-platform-7:
-    image: camunda/camunda-bpm-platform:run-7.23.0
-    # image: registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee:7.23.4
+    image: camunda/camunda-bpm-platform:run-7.24.0
+    # image: registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee:7.24.1
     pull_policy: always
     ports:
       - '9090:8080'

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <!-- COMMON GLOBAL -->
     <spring-boot.version>3.5.7</spring-boot.version>
-    <process-engine-api.version>1.3</process-engine-api.version>
+    <process-engine-api.version>1.4</process-engine-api.version>
     <camunda-platform-7-rest-client.version>7.23.5</camunda-platform-7-rest-client.version>
     <!-- TEST -->
     <mockito.version>6.1.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <!-- COMMON GLOBAL -->
     <spring-boot.version>3.5.7</spring-boot.version>
     <process-engine-api.version>1.4</process-engine-api.version>
-    <camunda-platform-7-rest-client.version>7.23.5</camunda-platform-7-rest-client.version>
+    <camunda-platform-7-rest-client.version>7.24.0</camunda-platform-7-rest-client.version>
     <!-- TEST -->
     <mockito.version>6.1.0</mockito.version>
     <assertj.version>3.27.6</assertj.version>


### PR DESCRIPTION
- Switch from `Future<T>` to `CompletableFuture<T>`
- Support Camunda 7.24