### PR TITLE
refactor: generate spring-configuration-metadata.json to simplify library configuration

### DIFF
--- a/engine-adapter/c7-embedded-spring-boot-starter/pom.xml
+++ b/engine-adapter/c7-embedded-spring-boot-starter/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>
       <scope>provided</scope>
@@ -73,5 +78,34 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>kapt</id>
+            <goals>
+              <goal>kapt</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>src/main/kotlin</sourceDir>
+              </sourceDirs>
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-configuration-processor</artifactId>
+                  <version>${spring-boot.version}</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/engine-adapter/c7-remote-spring-boot-starter/pom.xml
+++ b/engine-adapter/c7-remote-spring-boot-starter/pom.xml
@@ -30,6 +30,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Use subscription-based delivery using official Camunda client -->
     <dependency>
@@ -58,6 +63,30 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>kapt</id>
+            <goals>
+              <goal>kapt</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>src/main/kotlin</sourceDir>
+              </sourceDirs>
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-configuration-processor</artifactId>
+                  <version>${spring-boot.version}</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
## Context

@zambrovski - Assuming you feel that this change makes sense, would you place it in the [parent library](https://github.com/bpm-crafters/bpm-crafters-maven-parent) or in the affected ones (here)? Basically, you would have to set this for all modules, that provide configuration for the user (which are some, but not too many as far as i've seen. mostly the adapters and the worker).

If you support this change, i would also do this for the [bpm-crafters/process-engine-worker](https://github.com/bpm-crafters/process-engine-worker) and the [bpm-crafters/process-engine-adapters-camunda-8](https://github.com/bpm-crafters/process-engine-adapters-camunda-8)

  ## Summary

  Improve developer experience when configuring the Camunda 7 adapters by generating Spring configuration metadata for IDE autocomplete and documentation.

  ## Why This Change?

  When developers configure the Camunda 7 embedded or remote adapters in their `application.properties` or `application.yml` files, IDEs like IntelliJ IDEA and VS Code cannot provide autocomplete suggestions or inline documentation for the available configuration properties. This makes the library harder to discover and configure correctly.

  By adding the Spring Boot Configuration Processor and configuring Kotlin's annotation processing (kapt), the lib automatically generates `spring-configuration-metadata.json` files during the build. These metadata files enable IDEs to:

  - **Provide autocomplete** for all `dev.bpm-crafters.process-engine-api.adapter.c7.*` configuration properties
  - **Display inline documentation** explaining what each property does
  - **Show default values** and valid value types
  - **Validate configuration** and highlight potential errors before runtime

  This change simplifies the library configuration experience, reducing the need to constantly reference documentation and lowering the barrier to entry for new users.

  ## What Changed?

  - Added `spring-boot-configuration-processor` dependency to both Spring Boot starter modules (embedded and remote)
  - Configured Kotlin's kapt (Kotlin Annotation Processing Tool) to process configuration classes during compilation
  - The generated metadata files are automatically included in the JAR artifacts

**Before**
<img width="1057" height="608" alt="Bildschirmfoto 2025-12-05 um 14 24 03" src="https://github.com/user-attachments/assets/7551eeb7-f3b8-4b2c-9824-f88dff33075d" />

**After**
<img width="1057" height="608" alt="Bildschirmfoto 2025-12-05 um 14 32 04" src="https://github.com/user-attachments/assets/5fdf88ee-4a21-4e3e-b95a-70d9adcbc89d" />
