### PR TITLE
refactor: remove unused imports & fix compile issues in examples module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The library contains of the following Maven modules:
 
 ## Usage
 
-If you want to start usage, please add the BOM to your Maven project and add corresponding adapter implementation:
+If you want to start usage, please add the BOM to your Maven project and add the corresponding adapter implementation:
 
 ```xml
 <dependency>

--- a/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseThenStage.kt
+++ b/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseThenStage.kt
@@ -2,7 +2,6 @@ package dev.bpmcrafters.processengineapi.test
 
 import com.tngtech.jgiven.Stage
 import com.tngtech.jgiven.annotation.ExpectedScenarioState
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.toolisticon.testing.jgiven.JGivenKotlinStage
 import io.toolisticon.testing.jgiven.step
 import org.assertj.core.api.Assertions.assertThat

--- a/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/JGivenSpringBaseIntegrationTest.kt
+++ b/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/JGivenSpringBaseIntegrationTest.kt
@@ -2,7 +2,6 @@ package dev.bpmcrafters.processengineapi.test
 
 import com.tngtech.jgiven.annotation.ProvidedScenarioState
 import com.tngtech.jgiven.integration.spring.junit5.SpringScenarioTest
-import com.tngtech.jgiven.junit5.ScenarioTest
 
 abstract class JGivenSpringBaseIntegrationTest : SpringScenarioTest<BaseGivenWhenStage, BaseGivenWhenStage, BaseThenStage>() {
   @ProvidedScenarioState

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensions.kt
@@ -40,27 +40,6 @@ fun Task.toTaskInformation(candidates: Set<IdentityLink>, processDefinitionKey: 
     }
   )
 
-fun TaskEntity.toTaskInformation() =
-  TaskInformation(
-    taskId = this.id,
-    meta = mapOf(
-      CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
-      CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
-      CommonRestrictions.TENANT_ID to this.tenantId,
-      CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
-      "taskName" to this.name,
-      "taskDescription" to this.description,
-      "assignee" to this.assignee,
-      "creationDate" to this.createTime.toDateString(),
-      "followUpDate" to this.followUpDate.toDateString(),
-      "dueDate" to this.dueDate.toDateString(),
-      "formKey" to this.formKey,
-      "candidateUsers" to this.candidates.toUsersString(),
-      "candidateGroups" to this.candidates.toGroupsString(),
-      "lastUpdatedDate" to this.lastUpdated.toDateString()
-    )
-  )
-
 fun DelegateTask.toTaskInformation() =
   TaskInformation(
     taskId = this.id,
@@ -95,23 +74,6 @@ fun LockedExternalTask.toTaskInformation(): TaskInformation =
       TaskInformation.RETRIES to (this.retries?.toString() ?: ""),
     )
   )
-
-
-fun ExternalTaskEntity.toTaskInformation(): TaskInformation {
-  return TaskInformation(
-    taskId = this.id,
-    meta = mapOf(
-      CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
-      CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
-      CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
-      CommonRestrictions.TENANT_ID to this.tenantId,
-      CommonRestrictions.ACTIVITY_ID to this.activityId,
-      "topicName" to this.topicName,
-      "creationDate" to this.createTime.toDateString(),
-      TaskInformation.RETRIES to (this.retries?.toString() ?: ""),
-    )
-  )
-}
 
 /**
  * Converts engine internal representation into a string.

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullUserTaskDelivery.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullUserTaskDelivery.kt
@@ -1,7 +1,6 @@
 package dev.bpmcrafters.processengineapi.adapter.c7.embedded.task.delivery.pull
 
 import dev.bpmcrafters.processengineapi.CommonRestrictions
-import dev.bpmcrafters.processengineapi.adapter.c7.embedded.process.CachingProcessDefinitionMetaDataResolver
 import dev.bpmcrafters.processengineapi.adapter.c7.embedded.process.ProcessDefinitionMetaDataResolver
 import dev.bpmcrafters.processengineapi.adapter.c7.embedded.task.delivery.*
 import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
@@ -10,7 +9,6 @@ import dev.bpmcrafters.processengineapi.impl.task.filterBySubscription
 import dev.bpmcrafters.processengineapi.task.TaskInformation
 import dev.bpmcrafters.processengineapi.task.TaskType
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.TaskService
 import org.camunda.bpm.engine.task.IdentityLink
 import org.camunda.bpm.engine.task.Task

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/modification/C7UserTaskModificationApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/modification/C7UserTaskModificationApiImpl.kt
@@ -7,7 +7,6 @@ import dev.bpmcrafters.processengineapi.task.ChangePayloadModifyTaskCmd.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.TaskService
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/correlation/CorrelationApiImplTest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/correlation/CorrelationApiImplTest.kt
@@ -13,9 +13,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
-import java.util.concurrent.ExecutionException
 
 @ExtendWith(MockitoExtension::class)
 class CorrelationApiImplTest {

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/AbstractC7EmbeddedApiITest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/AbstractC7EmbeddedApiITest.kt
@@ -20,8 +20,8 @@ abstract class AbstractC7EmbeddedApiITest(override val processTestHelper: Proces
 
     val processEngine: ProcessEngine = object : StandaloneInMemProcessEngineConfiguration() {
       init {
-        history = ProcessEngineConfiguration.HISTORY_AUDIT
-        databaseSchemaUpdate = ProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE
+        history = HISTORY_AUDIT
+        databaseSchemaUpdate = DB_SCHEMA_UPDATE_TRUE
         jobExecutorActivate = false
         expressionManager = MockExpressionManager()
       }

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImplTest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImplTest.kt
@@ -3,10 +3,8 @@ package dev.bpmcrafters.processengineapi.adapter.c7.embedded.process
 import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
-import org.camunda.bpm.engine.ProcessEngine
 import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.RuntimeService
-import org.camunda.bpm.engine.repository.ProcessDefinitionQuery
 import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder
 import org.camunda.bpm.engine.runtime.ProcessInstance
 import org.camunda.community.mockito.QueryMocks
@@ -14,7 +12,6 @@ import org.camunda.community.mockito.process.ProcessDefinitionFake
 import org.camunda.community.mockito.process.ProcessInstanceFake
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Answers
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*

--- a/engine-adapter/c7-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/C7EmbeddedAdapterProperties.kt
+++ b/engine-adapter/c7-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/C7EmbeddedAdapterProperties.kt
@@ -3,7 +3,6 @@ package dev.bpmcrafters.processengineapi.adapter.c7.embedded.springboot
 import dev.bpmcrafters.processengineapi.adapter.c7.embedded.springboot.C7EmbeddedAdapterProperties.Companion.DEFAULT_PREFIX
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.NestedConfigurationProperty
-import org.springframework.core.Ordered
 import org.springframework.validation.annotation.Validated
 
 @ConfigurationProperties(prefix = DEFAULT_PREFIX)

--- a/engine-adapter/c7-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/initial/C7EmbeddedInitialPullOnStartupAutoConfiguration.kt
+++ b/engine-adapter/c7-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/initial/C7EmbeddedInitialPullOnStartupAutoConfiguration.kt
@@ -6,7 +6,6 @@ import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PostConstruct
 import org.camunda.bpm.engine.ExternalTaskService
-import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.TaskService
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfigureAfter

--- a/engine-adapter/c7-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/initial/C7EmbeddedInitialPullUserTasksDeliveryBinding.kt
+++ b/engine-adapter/c7-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/initial/C7EmbeddedInitialPullUserTasksDeliveryBinding.kt
@@ -5,10 +5,8 @@ import dev.bpmcrafters.processengineapi.adapter.c7.embedded.springboot.initial.C
 import dev.bpmcrafters.processengineapi.adapter.c7.embedded.task.delivery.pull.EmbeddedPullUserTaskDelivery
 import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.TaskService
 import org.camunda.bpm.spring.boot.starter.event.ProcessApplicationStartedEvent
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.event.EventListener
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order

--- a/engine-adapter/c7-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/schedule/C7EmbeddedUserTaskPullStrategyAutoConfiguration.kt
+++ b/engine-adapter/c7-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/schedule/C7EmbeddedUserTaskPullStrategyAutoConfiguration.kt
@@ -7,7 +7,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.scheduling.config.ScheduledTaskRegistrar
 import java.util.concurrent.TimeUnit.SECONDS
 
 private val logger = KotlinLogging.logger {}

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/correlation/CorrelationApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/correlation/CorrelationApiImpl.kt
@@ -12,7 +12,6 @@ import org.camunda.community.rest.client.api.MessageApiClient
 import org.camunda.community.rest.client.model.CorrelationMessageDto
 import org.camunda.community.rest.variables.ValueMapper
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/correlation/SignalApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/correlation/SignalApiImpl.kt
@@ -11,7 +11,6 @@ import org.camunda.community.rest.client.api.SignalApiClient
 import org.camunda.community.rest.client.model.SignalDto
 import org.camunda.community.rest.variables.ValueMapper
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/deploy/DeploymentApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/deploy/DeploymentApiImpl.kt
@@ -9,7 +9,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.community.rest.client.api.DeploymentApiClient
 import org.camunda.community.rest.client.model.DeploymentWithDefinitionsDto
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImpl.kt
@@ -11,7 +11,6 @@ import org.camunda.community.rest.client.api.ProcessDefinitionApiClient
 import org.camunda.community.rest.client.model.*
 import org.camunda.community.rest.variables.ValueMapper
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImpl.kt
@@ -11,7 +11,6 @@ import org.camunda.community.rest.client.model.ExternalTaskFailureDto
 import org.camunda.community.rest.variables.ValueMapper
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/NoOpServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/NoOpServiceTaskCompletionApiImpl.kt
@@ -6,7 +6,6 @@ import dev.bpmcrafters.processengineapi.task.CompleteTaskCmd
 import dev.bpmcrafters.processengineapi.task.FailTaskCmd
 import dev.bpmcrafters.processengineapi.task.ServiceTaskCompletionApi
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 class NoOpServiceTaskCompletionApiImpl : ServiceTaskCompletionApi {
   override fun completeTask(cmd: CompleteTaskCmd): CompletableFuture<Empty> {

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/NoOpUserTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/NoOpUserTaskCompletionApiImpl.kt
@@ -5,7 +5,6 @@ import dev.bpmcrafters.processengineapi.task.CompleteTaskByErrorCmd
 import dev.bpmcrafters.processengineapi.task.CompleteTaskCmd
 import dev.bpmcrafters.processengineapi.task.UserTaskCompletionApi
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 class NoOpUserTaskCompletionApiImpl : UserTaskCompletionApi {
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImpl.kt
@@ -6,7 +6,6 @@ import dev.bpmcrafters.processengineapi.task.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 import org.camunda.bpm.client.task.ExternalTaskService as ClientExternalTaskService
 
 private val logger = KotlinLogging.logger {}

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/UserTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/UserTaskCompletionApiImpl.kt
@@ -12,7 +12,6 @@ import org.camunda.community.rest.client.model.CompleteTaskDto
 import org.camunda.community.rest.client.model.TaskBpmnErrorDto
 import org.camunda.community.rest.variables.ValueMapper
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/modification/UserTaskModificationApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/modification/UserTaskModificationApiImpl.kt
@@ -11,7 +11,6 @@ import org.camunda.community.rest.client.model.PatchVariablesDto
 import org.camunda.community.rest.client.model.UserIdDto
 import org.camunda.community.rest.variables.ValueMapper
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 
 private val logger = KotlinLogging.logger {}
 

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByMessageTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByMessageTest.kt
@@ -30,6 +30,7 @@ class StartProcessApiImplByMessageTest {
   private val valueMapper: ValueMapper = TestFixtures.valueMapper()
 
   @Spy
+  @Suppress("unused")
   private val processDefinitionMetaDataResolver = CachingProcessDefinitionMetaDataResolver(
     processDefinitionApiClient
   )

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensionsKtTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensionsKtTest.kt
@@ -117,7 +117,6 @@ class TaskInformationExtensionsKtTest {
 
   @Test
   fun `should map null date to empty string for LockedExternalTaskDto`() {
-    val now = OffsetDateTime.now()
 
     val lockedTask = LockedExternalTaskDto()
       .processDefinitionId("processDefinitionId")
@@ -128,7 +127,6 @@ class TaskInformationExtensionsKtTest {
       .activityId("activityId")
       .activityInstanceId("activityInstanceId")
       .createTime(null)
-
 
     val taskInformation = lockedTask.toTaskInformation(processDefinitionMetaDataResolver)
 
@@ -141,6 +139,5 @@ class TaskInformationExtensionsKtTest {
     identityLink.groupId = groupId
     return identityLink
   }
-
 
 }

--- a/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteTaskApiSubscribedITest.kt
+++ b/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteTaskApiSubscribedITest.kt
@@ -1,11 +1,9 @@
 package dev.bpmcrafters.processengineapi.adapter.c7.remote.springboot
 
-import io.toolisticon.testing.jgiven.AND
 import io.toolisticon.testing.jgiven.GIVEN
 import io.toolisticon.testing.jgiven.THEN
 import io.toolisticon.testing.jgiven.WHEN
 import org.junit.jupiter.api.Test
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 
 /**

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -88,6 +88,20 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>17</source>
+          <target>17</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
added annotation processor path configuration to the examples parent POM to enable Lombok processing for all Java example modules. Also removed unused imports.