### PR TITLE
feat: support null values in PayloadSupplier for C7 adapters (#268)

### DIFF
--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImpl.kt
@@ -41,7 +41,7 @@ class StartProcessApiImpl(
             StartProcessInstanceDto()
               .apply {
                 if (payload.containsKey(CommonRestrictions.BUSINESS_KEY)) {
-                  this.businessKey = payload.getValue(CommonRestrictions.BUSINESS_KEY).toString()
+                  this.businessKey = payload[CommonRestrictions.BUSINESS_KEY]?.toString()
                 }
                 this.variables = valueMapper.mapValues(payload)
               }
@@ -65,7 +65,7 @@ class StartProcessApiImpl(
               )
               .apply {
                 if (payload.containsKey(CommonRestrictions.BUSINESS_KEY)) {
-                  this.businessKey = payload[CommonRestrictions.BUSINESS_KEY].toString()
+                  this.businessKey = payload[CommonRestrictions.BUSINESS_KEY]?.toString()
                 }
               }
           )

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensions.kt
@@ -91,7 +91,7 @@ fun Set<IdentityLinkDto>.toGroupsString() = this.mapNotNull { it.groupId }.sorte
 fun Set<IdentityLinkDto>.toUsersString() = this.mapNotNull { it.userId }.sorted().joinToString(",")
 
 
-fun <T : Any> Map<String, T>.filterBySubscription(subscription: TaskSubscriptionHandle): Map<String, T> =
+fun <T : Any?> Map<String, T>.filterBySubscription(subscription: TaskSubscriptionHandle): Map<String, T> =
   if (subscription.payloadDescription != null) {
     if (subscription.payloadDescription!!.isEmpty()) {
       mapOf()


### PR DESCRIPTION
- Fixed null-safety issues in StartProcessApiImpl
- Updated generic constraints in TaskInformationExtensions
- All payloads now support nullable values

Related to bpm-crafters/process-engine-api#268