### PR TITLE
fix: don't put empty strings for nulls into meta when creating TaskInformation

### DIFF
--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensions.kt
@@ -4,19 +4,15 @@ import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.task.TaskInformation
 import org.camunda.bpm.engine.delegate.DelegateTask
 import org.camunda.bpm.engine.externaltask.LockedExternalTask
-import org.camunda.bpm.engine.impl.persistence.entity.ExternalTaskEntity
-import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity
 import org.camunda.bpm.engine.task.IdentityLink
 import org.camunda.bpm.engine.task.Task
-import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
 import java.util.*
 
 fun Task.toTaskInformation(candidates: Set<IdentityLink>, processDefinitionKey: String? = null) =
   TaskInformation(
     taskId = this.id,
-    meta = mapOf(
+    meta = metaOf(
+      CommonRestrictions.PROCESS_DEFINITION_KEY to processDefinitionKey,
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
@@ -31,19 +27,13 @@ fun Task.toTaskInformation(candidates: Set<IdentityLink>, processDefinitionKey: 
       "candidateUsers" to candidates.toUsersString(),
       "candidateGroups" to candidates.toGroupsString(),
       "lastUpdatedDate" to this.lastUpdated.toDateString()
-    ).let {
-      if (processDefinitionKey != null) {
-        it + (CommonRestrictions.PROCESS_DEFINITION_KEY to processDefinitionKey)
-      } else {
-        it
-      }
-    }
+    )
   )
 
 fun DelegateTask.toTaskInformation() =
   TaskInformation(
     taskId = this.id,
-    meta = mapOf(
+    meta = metaOf(
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
@@ -63,7 +53,7 @@ fun DelegateTask.toTaskInformation() =
 fun LockedExternalTask.toTaskInformation(): TaskInformation =
   TaskInformation(
     taskId = this.id,
-    meta = mapOf(
+    meta = metaOf(
       CommonRestrictions.ACTIVITY_ID to this.activityId,
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
@@ -71,25 +61,34 @@ fun LockedExternalTask.toTaskInformation(): TaskInformation =
       CommonRestrictions.TENANT_ID to this.tenantId,
       "topicName" to this.topicName,
       "creationDate" to this.createTime.toDateString(),
-      TaskInformation.RETRIES to (this.retries?.toString() ?: ""),
+      TaskInformation.RETRIES to this.retries?.toString(),
     )
   )
 
 /**
  * Converts engine internal representation into a string.
  */
-fun Date?.toDateString() = this?.toInstant()?.toIso8601() ?: ""
-
-/**
- * Converts to offset date time in ISO8601 in UTC.
- */
-fun Instant.toIso8601() = OffsetDateTime.ofInstant(this, ZoneOffset.UTC).toString()
+fun Date?.toDateString() = this?.toInstant()?.toString()
 
 /**
  * Extracts candidates groups as a comma-separated string.
  */
 fun Set<IdentityLink>.toGroupsString() = this.mapNotNull { it.groupId }.sorted().joinToString(",")
+
 /**
  * Extracts candidates users as a comma-separated string.
  */
 fun Set<IdentityLink>.toUsersString() = this.mapNotNull { it.userId }.sorted().joinToString(",")
+
+/**
+ * Creates a map of the provided pairs.
+ *
+ * If the 2nd component of a pair is `null`, the pair is dropped and not added to the resulting map.
+ */
+fun metaOf(vararg pairs: Pair<String, String?>): Map<String, String> =
+  sequenceOf(*pairs)
+    .filter { it.second != null }
+    .associate {
+      @Suppress("UNCHECKED_CAST")
+      it as Pair<String, String>
+    }

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
@@ -6,15 +6,20 @@ import org.camunda.bpm.engine.impl.persistence.entity.IdentityLinkEntity
 import org.camunda.bpm.engine.task.IdentityLink
 import org.camunda.community.mockito.delegate.DelegateTaskFake
 import org.camunda.community.mockito.task.TaskFake
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.time.Instant
 import java.util.*
 
 class TaskInformationExtensionsKtTest {
 
-  @Test
-  fun `should map Task`() {
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = ["Sat, 12 Aug 1995 13:30:00 GMT+0430"])
+  fun `should map Task`(maybeNullDate: Date?) {
     val now = Date.from(Instant.now())
+
     val task = TaskFake.builder()
       .id("taskId")
       .processDefinitionId("processDefinitionId")
@@ -25,10 +30,10 @@ class TaskInformationExtensionsKtTest {
       .description("description")
       .assignee("assignee")
       .createTime(now)
-      .followUpDate(now)
-      .dueDate(now)
+      .followUpDate(maybeNullDate)
+      .dueDate(maybeNullDate)
       .formKey("formKey")
-      .lastUpdated(now)
+      .lastUpdated(maybeNullDate)
       .build()
 
     val identityLinks =
@@ -45,16 +50,24 @@ class TaskInformationExtensionsKtTest {
     assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")
     assertThat(taskInformation.meta["assignee"]).isEqualTo("assignee")
     assertThat(taskInformation.meta["creationDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["followUpDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["dueDate"]).isEqualTo(now.toDateString())
     assertThat(taskInformation.meta["formKey"]).isEqualTo("formKey")
     assertThat(taskInformation.meta["candidateUsers"]).isEqualTo("user-1,user-2")
     assertThat(taskInformation.meta["candidateGroups"]).isEqualTo("group")
-    assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(now.toDateString())
+    if (maybeNullDate == null) {
+      assertThat(taskInformation.meta).doesNotContainKey("followUpDate")
+      assertThat(taskInformation.meta).doesNotContainKey("dueDate")
+      assertThat(taskInformation.meta).doesNotContainKey("lastUpdatedDate")
+    } else {
+      assertThat(taskInformation.meta["followUpDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["dueDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(maybeNullDate.toDateString())
+    }
   }
 
-  @Test
-  fun `should map DelegateTask`() {
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = ["Sat, 12 Aug 1995 13:30:00 GMT+0430"])
+  fun `should map DelegateTask`(maybeNullDate: Date?) {
     val now = Date.from(Instant.now())
 
     var delegateTask = DelegateTaskFake("taskId")
@@ -66,9 +79,9 @@ class TaskInformationExtensionsKtTest {
     delegateTask = delegateTask.withDescription("description")
     delegateTask = delegateTask.withAssignee("assignee")
     delegateTask = delegateTask.withCreateTime(now)
-    delegateTask = delegateTask.withFollowUpDate(now)
-    delegateTask = delegateTask.withLastUpdated(now)
-    delegateTask.dueDate = now
+    delegateTask = delegateTask.withFollowUpDate(maybeNullDate)
+    delegateTask = delegateTask.withLastUpdated(maybeNullDate)
+    delegateTask.dueDate = maybeNullDate
     delegateTask.addGroupIdentityLink("group-1", "CANDIDATE")
     delegateTask.addGroupIdentityLink("group-2", "CANDIDATE")
     delegateTask.addUserIdentityLink("user-1", "CANDIDATE")
@@ -84,13 +97,18 @@ class TaskInformationExtensionsKtTest {
     assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")
     assertThat(taskInformation.meta["assignee"]).isEqualTo("assignee")
     assertThat(taskInformation.meta["creationDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["followUpDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["dueDate"]).isEqualTo(now.toDateString())
     assertThat(taskInformation.meta["formKey"]).isNull()
     assertThat(taskInformation.meta["candidateUsers"]).isEqualTo("user-1,user-2")
     assertThat(taskInformation.meta["candidateGroups"]).isEqualTo("group-1,group-2")
-    assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(now.toDateString())
-
+    if (maybeNullDate == null) {
+      assertThat(taskInformation.meta).doesNotContainKey("followUpDate")
+      assertThat(taskInformation.meta).doesNotContainKey("dueDate")
+      assertThat(taskInformation.meta).doesNotContainKey("lastUpdatedDate")
+    } else {
+      assertThat(taskInformation.meta["followUpDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["dueDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(maybeNullDate.toDateString())
+    }
   }
 
   private fun identityLink(userId: String? = null, groupId: String? = null): IdentityLink {
@@ -99,6 +117,5 @@ class TaskInformationExtensionsKtTest {
     identityLink.groupId = groupId
     return identityLink
   }
-
 
 }

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensions.kt
@@ -15,7 +15,7 @@ import java.util.*
 fun LockedExternalTaskDto.toTaskInformation(pdMetaDataResolver: ProcessDefinitionMetaDataResolver): TaskInformation =
   TaskInformation(
     taskId = this.id!!,
-    meta = mapOf(
+    meta = metaOf(
       CommonRestrictions.ACTIVITY_ID to this.activityId,
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
@@ -23,14 +23,14 @@ fun LockedExternalTaskDto.toTaskInformation(pdMetaDataResolver: ProcessDefinitio
       CommonRestrictions.TENANT_ID to this.tenantId,
       "topicName" to this.topicName,
       "creationDate" to this.createTime.toDateString(),
-      TaskInformation.RETRIES to (this.retries?.toString() ?: ""),
+      TaskInformation.RETRIES to this.retries?.toString(),
     ).enrichWithProcessDefinitionMetadata(this.processDefinitionId!!, pdMetaDataResolver)
   )
 
 fun TaskWithAttachmentAndCommentDto.toTaskInformation(candidates: Set<IdentityLinkDto>, pdMetaDataResolver: ProcessDefinitionMetaDataResolver) =
   TaskInformation(
     taskId = this.id!!,
-    meta = mapOf(
+    meta = metaOf(
       CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
@@ -68,17 +68,12 @@ fun Map<String, String>.enrichWithProcessDefinitionMetadata(processDefinitionId:
 /**
  * Converts engine internal representation into a string.
  */
-fun Date?.toDateString() = this?.toInstant()?.toIso8601() ?: ""
+fun Date?.toDateString() = this?.toInstant()?.toString()
 
 /**
  * Converts offset date time to string representation in ISO8601 in UTC.
  */
-fun OffsetDateTime?.toDateString() = this?.atZoneSameInstant(ZoneOffset.UTC)?.toString() ?: ""
-
-/**
- * Converts to offset date time in ISO8601 in UTC.
- */
-fun Instant.toIso8601() = OffsetDateTime.ofInstant(this, ZoneOffset.UTC).toString()
+fun OffsetDateTime?.toDateString() = this?.atZoneSameInstant(ZoneOffset.UTC)?.toString()
 
 /**
  * Extracts candidates groups as a comma-separated string.
@@ -90,6 +85,18 @@ fun Set<IdentityLinkDto>.toGroupsString() = this.mapNotNull { it.groupId }.sorte
  */
 fun Set<IdentityLinkDto>.toUsersString() = this.mapNotNull { it.userId }.sorted().joinToString(",")
 
+/**
+ * Creates a map of the provided pairs.
+ *
+ * If the 2nd component of a pair is `null`, the pair is dropped and not added to the resulting map.
+ */
+fun metaOf(vararg pairs: Pair<String, String?>): Map<String, String> =
+  sequenceOf(*pairs)
+    .filter { it.second != null }
+    .associate {
+      @Suppress("UNCHECKED_CAST")
+      it as Pair<String, String>
+    }
 
 fun <T : Any> Map<String, T>.filterBySubscription(subscription: TaskSubscriptionHandle): Map<String, T> =
   if (subscription.payloadDescription != null) {

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/ExternalTaskExtensions.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/ExternalTaskExtensions.kt
@@ -1,13 +1,14 @@
 package dev.bpmcrafters.processengineapi.adapter.c7.remote.task.delivery.subscribe
 
 import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.adapter.c7.remote.task.delivery.metaOf
 import dev.bpmcrafters.processengineapi.adapter.c7.remote.task.delivery.toDateString
 import dev.bpmcrafters.processengineapi.task.TaskInformation
 import org.camunda.bpm.client.task.ExternalTask
 
 fun ExternalTask.toTaskInformation(): TaskInformation = TaskInformation(
   taskId = this.id,
-  meta = mapOf(
+  meta = metaOf(
     CommonRestrictions.ACTIVITY_ID to this.activityId,
     CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
     CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
@@ -16,6 +17,6 @@ fun ExternalTask.toTaskInformation(): TaskInformation = TaskInformation(
     CommonRestrictions.TENANT_ID to this.tenantId,
     "topicName" to this.topicName,
     "creationDate" to this.createTime.toDateString(),
-    TaskInformation.RETRIES to (this.retries?.toString() ?: ""),
+    TaskInformation.RETRIES to this.retries?.toString(),
   )
 )

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensionsKtTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensionsKtTest.kt
@@ -9,7 +9,9 @@ import org.camunda.community.rest.client.api.ProcessDefinitionApiClient
 import org.camunda.community.rest.client.model.IdentityLinkDto
 import org.camunda.community.rest.client.model.LockedExternalTaskDto
 import org.camunda.community.rest.client.model.TaskWithAttachmentAndCommentDto
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.mock
 import java.time.OffsetDateTime
 
@@ -22,9 +24,12 @@ class TaskInformationExtensionsKtTest {
     versionTags = mutableMapOf("processDefinitionId" to "versionTag")
   )
 
-  @Test
-  fun `should map TaskWithAttachmentAndCommentDto`() {
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = ["2007-12-03T10:15:30+01:00"])
+  fun `should map TaskWithAttachmentAndCommentDto`(maybeNullDate: OffsetDateTime?) {
     val now = OffsetDateTime.now()
+
     val task = TaskWithAttachmentAndCommentDto()
       .id("taskId")
       .processDefinitionId("processDefinitionId")
@@ -35,10 +40,10 @@ class TaskInformationExtensionsKtTest {
       .description("description")
       .assignee("assignee")
       .created(now)
-      .followUp(now)
-      .due(now)
+      .followUp(maybeNullDate)
+      .due(maybeNullDate)
       .formKey("formKey")
-      .lastUpdated(now)
+      .lastUpdated(maybeNullDate)
 
     val identityLinks =
       listOf(identityLink(groupId = "group"), identityLink(userId = "user-1"), identityLink(userId = "user-2"))
@@ -53,18 +58,28 @@ class TaskInformationExtensionsKtTest {
     assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")
     assertThat(taskInformation.meta["assignee"]).isEqualTo("assignee")
     assertThat(taskInformation.meta["creationDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["followUpDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["dueDate"]).isEqualTo(now.toDateString())
+    assertThat(taskInformation.meta["followUpDate"]).isEqualTo(maybeNullDate.toDateString())
+    assertThat(taskInformation.meta["dueDate"]).isEqualTo(maybeNullDate.toDateString())
     assertThat(taskInformation.meta["formKey"]).isEqualTo("formKey")
     assertThat(taskInformation.meta["candidateUsers"]).isEqualTo("user-1,user-2")
     assertThat(taskInformation.meta["candidateGroups"]).isEqualTo("group")
-    assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(now.toDateString())
+    assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(maybeNullDate.toDateString())
+    if (maybeNullDate == null) {
+      assertThat(taskInformation.meta).doesNotContainKey("followUpDate")
+      assertThat(taskInformation.meta).doesNotContainKey("dueDate")
+      assertThat(taskInformation.meta).doesNotContainKey("lastUpdatedDate")
+    } else {
+      assertThat(taskInformation.meta["followUpDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["dueDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(maybeNullDate.toDateString())
+    }
   }
 
-  @Test
-  fun `should map LockedExternalTask`() {
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(ints = [3])
+  fun `should map TaskWithAttachmentAndCommentDto`(maybeNullRetryCount: Int?) {
     val now = OffsetDateTime.now()
-    val retryCount = 3
 
     val lockedTask = LockedExternalTaskDto()
       .processDefinitionId("processDefinitionId")
@@ -75,7 +90,7 @@ class TaskInformationExtensionsKtTest {
       .activityId("activityId")
       .activityInstanceId("activityInstanceId")
       .createTime(now)
-      .retries(retryCount)
+      .retries(maybeNullRetryCount)
 
     val taskInformation = lockedTask.toTaskInformation(processDefinitionMetaDataResolver)
 
@@ -86,51 +101,11 @@ class TaskInformationExtensionsKtTest {
     assertThat(taskInformation.meta[CommonRestrictions.TENANT_ID]).isEqualTo("tenantId")
     assertThat(taskInformation.meta["topicName"]).isEqualTo("topicName")
     assertThat(taskInformation.meta["creationDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta[TaskInformation.RETRIES]).isEqualTo(retryCount.toString())
-  }
-
-  @Test
-  fun `should map null date to empty string for TaskWithAttachmentAndCommentDto`() {
-
-    val task = TaskWithAttachmentAndCommentDto()
-      .id("taskId")
-      .processDefinitionId("processDefinitionId")
-      .processInstanceId("processInstanceId")
-      .tenantId("tenantId")
-      .taskDefinitionKey("taskDefinitionKey")
-      .name("name")
-      .description("description")
-      .assignee("assignee")
-      .formKey("formKey")
-      .created(null)
-      .followUp(null)
-      .due(null)
-      .lastUpdated(null)
-
-    val taskInformation = task.toTaskInformation(setOf(), processDefinitionMetaDataResolver)
-
-    assertThat(taskInformation.meta["creationDate"]).isEqualTo("")
-    assertThat(taskInformation.meta["followUpDate"]).isEqualTo("")
-    assertThat(taskInformation.meta["dueDate"]).isEqualTo("")
-    assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo("")
-  }
-
-  @Test
-  fun `should map null date to empty string for LockedExternalTaskDto`() {
-
-    val lockedTask = LockedExternalTaskDto()
-      .processDefinitionId("processDefinitionId")
-      .processInstanceId("processInstanceId")
-      .tenantId("tenantId")
-      .topicName("topicName")
-      .id("taskId")
-      .activityId("activityId")
-      .activityInstanceId("activityInstanceId")
-      .createTime(null)
-
-    val taskInformation = lockedTask.toTaskInformation(processDefinitionMetaDataResolver)
-
-    assertThat(taskInformation.meta["creationDate"]).isEqualTo("")
+    if (maybeNullRetryCount == null) {
+      assertThat(taskInformation.meta).doesNotContainKey(TaskInformation.RETRIES)
+    } else {
+      assertThat(taskInformation.meta[TaskInformation.RETRIES]).isEqualTo(maybeNullRetryCount.toString())
+    }
   }
 
   private fun identityLink(userId: String? = null, groupId: String? = null): IdentityLinkDto {


### PR DESCRIPTION
Closes #168