### PR TITLE
refactor: use CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS constant

### DIFF
--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
@@ -203,7 +203,7 @@ class EmbeddedPullServiceTaskDelivery(
   }
 
   private fun getLockDurationForSubscription(subscription: TaskSubscriptionHandle): Long {
-    val customLockDuration = subscription.restrictions["workerLockDurationInMilliseconds"]
+    val customLockDuration = subscription.restrictions[CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS]
     return customLockDuration?.toLong() ?: (lockDurationInSeconds * 1000)
   }
 
@@ -212,7 +212,7 @@ class EmbeddedPullServiceTaskDelivery(
       && (this.taskDescriptionKey == null || this.taskDescriptionKey == task.topicName)
       && this.restrictions
       .minus( // ignore some restrictions that are not relevant for external tasks or are already handled
-        "workerLockDurationInMilliseconds"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS
       )
       .all {
         when (it.key) {

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDeliveryTest.kt
@@ -1,5 +1,6 @@
 package dev.bpmcrafters.processengineapi.adapter.c7.embedded.task.delivery.pull
 
+import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
 import dev.bpmcrafters.processengineapi.task.TaskType
 import org.assertj.core.api.Assertions.assertThat
@@ -26,7 +27,7 @@ internal class EmbeddedPullServiceTaskDeliveryTest {
   fun `matches handles workerLockDurationInMilliseconds`() {
     val subscription = TaskSubscriptionHandle(
       taskType = TaskType.EXTERNAL,
-      restrictions = mapOf("workerLockDurationInMilliseconds" to "5000"),
+      restrictions = mapOf(CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS to "5000"),
       taskDescriptionKey = "topic",
       payloadDescription = null,
       action = { _, _ -> },

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullServiceTaskDelivery.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullServiceTaskDelivery.kt
@@ -246,7 +246,7 @@ class PullServiceTaskDelivery(
   private fun getLockDurationForSubscription(
     restrictions: Map<String, String>,
   ): Long {
-    val customLockDuration = restrictions["workerLockDurationInMilliseconds"]
+    val customLockDuration = restrictions[CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS]
     return customLockDuration?.toLong() ?: (lockDurationInSeconds * 1000)
   }
 
@@ -255,7 +255,7 @@ class PullServiceTaskDelivery(
       || subscription.taskDescriptionKey == task.topicName)
       && subscription.restrictions
       .minus( // ignore some restrictions which are not relevant for external tasks
-        "workerLockDurationInMilliseconds"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS
       ).all {
         when (it.key) {
           CommonRestrictions.EXECUTION_ID -> it.value == task.executionId

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingServiceTaskDelivery.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingServiceTaskDelivery.kt
@@ -100,7 +100,7 @@ class SubscribingServiceTaskDelivery(
       || this.taskDescriptionKey == externalTask.topicName)
       && this.restrictions
       .minus( // ignore some restrictions which are not relevant for external tasks
-        "workerLockDurationInMilliseconds"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS
       ).all {
         when (it.key) {
           CommonRestrictions.EXECUTION_ID -> it.value == externalTask.executionId

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullServiceTaskDeliveryTest.kt
@@ -1,5 +1,6 @@
 package dev.bpmcrafters.processengineapi.adapter.c7.remote.task.delivery.pull
 
+import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.adapter.c7.remote.process.ProcessDefinitionMetaDataResolver
 import dev.bpmcrafters.processengineapi.adapter.c7.remote.task.delivery.pull.PullServiceTaskDeliveryMetrics.DropReason.EXPIRED_WHILE_IN_QUEUE
 import dev.bpmcrafters.processengineapi.adapter.c7.remote.task.delivery.pull.PullServiceTaskDeliveryMetrics.DropReason.NO_MATCHING_SUBSCRIPTIONS
@@ -377,7 +378,7 @@ internal class PullServiceTaskDeliveryTest {
   @Test
   fun `matches handles workerLockDurationInMilliseconds`() {
     val subscription = mockTaskSubscriptionHandle().copy(
-      restrictions = mapOf("workerLockDurationInMilliseconds" to "5000")
+      restrictions = mapOf(CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS to "5000")
     )
     val task = mockLockedExternalTaskDto("1")
 

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingServiceTaskDeliveryTest.kt
@@ -1,5 +1,6 @@
 package dev.bpmcrafters.processengineapi.adapter.c7.remote.task.delivery.subscribe
 
+import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
 import dev.bpmcrafters.processengineapi.task.TaskType
 import org.assertj.core.api.Assertions.assertThat
@@ -22,7 +23,7 @@ internal class SubscribingServiceTaskDeliveryTest {
   fun `matches handles workerLockDurationInMilliseconds`() {
     val subscription = TaskSubscriptionHandle(
       taskType = TaskType.EXTERNAL,
-      restrictions = mapOf("workerLockDurationInMilliseconds" to "5000"),
+      restrictions = mapOf(CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS to "5000"),
       taskDescriptionKey = "topic",
       payloadDescription = null,
       action = { _, _ -> },


### PR DESCRIPTION
## What

Replaces the hardcoded `"workerLockDurationInMilliseconds"` restriction-key string with the `CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS` constant, which was introduced in `process-engine-api` 1.6 (commit `bb1a250`).

This aligns the lock-duration key with how every other restriction key (`EXECUTION_ID`, `ACTIVITY_ID`, `BUSINESS_KEY`, `TENANT_ID`, …) is already referenced in the C7 adapters, removing the last raw restriction-key literal in the codebase.

## Why

Using the constant avoids silent breakage if the key is ever renamed in `process-engine-api`, and keeps the adapters consistent. The constant resolves to the exact same value (`"workerLockDurationInMilliseconds"`), so there is no behavior change.

## Changes

Main sources (already imported `CommonRestrictions`):
- `c7-remote-core` `PullServiceTaskDelivery` — lock-duration lookup + `minus(...)` filter
- `c7-embedded-core` `EmbeddedPullServiceTaskDelivery` — lock-duration lookup + `minus(...)` filter
- `c7-remote-core` `SubscribingServiceTaskDelivery` — `minus(...)` filter

Test sources (added the `CommonRestrictions` import):
- `PullServiceTaskDeliveryTest`, `SubscribingServiceTaskDeliveryTest`, `EmbeddedPullServiceTaskDeliveryTest`

The backtick test-method names that mention the key were intentionally left unchanged (display names, not keys).

## Notes

- Requires `process-engine-api` ≥ 1.6 — already satisfied (`process-engine-api.version` is `1.6` in the root `pom.xml`).
- `test-compile` passes for both core modules.