### PR TITLE
chore(ci): pin github actions to exact version tags

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -35,14 +35,14 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Expose branch name
         run: echo ${{ github.ref }}
 
       # Setup JDK and Maven
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,11 +14,11 @@ jobs:
     name: Build and run tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       # Setup JDK and .m2/settings.xml
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@v7.0.0
     - name: Create Release Notes Markdown
       uses: docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0
       env:
@@ -27,7 +27,7 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Create a Draft Release Notes on GitHub
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@v1.1.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:


### PR DESCRIPTION
## What

Pin all external GitHub Actions to exact version tags (`@vX.Y.Z`) instead of moving references (major-only `@vX` or branch refs).

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v7` | `@v7.0.0` |
| `actions/setup-java` | `@v5` | `@v5.3.0` |
| `actions/checkout` (release-notes) | `@master` ⚠️ branch ref | `@v7.0.0` |
| `actions/create-release` | `@v1` | `@v1.1.4` |

Already pinned, left untouched: `codecov/codecov-action@v7.0.0`, `docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0`. Local reusable workflows (`./...`) are not affected (none present).

## Why

Moving refs silently re-resolve over time:
- **`@master` in `release-notes.yml` was a branch ref** — it follows whatever lands on the action's default branch, with no version guarantee at all. Now pinned to a released tag.
- Major-only tags (`@v7`, `@v5`, `@v1`) move with every minor/patch release within that major.

All updates stay within the **same major version**, so no breaking changes are introduced.

Tag-pinning protects against major drift. The next level of hardening would be **full-SHA pinning** (immutable commit), which additionally protects against a tag being force-moved — a follow-up worth considering.

## Verification

- Grep confirms no moving refs remain.
- `actionlint` parses all workflows cleanly; the only reported items are pre-existing shellcheck/script-hygiene warnings, untouched by this change.