### PR TITLE
Support start process instance at element by message

### DIFF
--- a/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseGivenWhenStage.kt
+++ b/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseGivenWhenStage.kt
@@ -7,6 +7,7 @@ import dev.bpmcrafters.processengineapi.decision.DecisionByRefEvaluationCommand
 import dev.bpmcrafters.processengineapi.decision.DecisionEvaluationResult
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
 import dev.bpmcrafters.processengineapi.task.*
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -81,6 +82,16 @@ class BaseGivenWhenStage : Stage<BaseGivenWhenStage>() {
     instanceId = processTestHelper.getStartProcessApi().startProcess(
       StartProcessByDefinitionAtElementCmd(
         definitionKey = definitionKey,
+        elementId = elementId,
+        payloadSupplier = { emptyMap() },
+      )
+    ).get().instanceId
+  }
+
+  fun `start process by message at element`(messageName: String, elementId: String) = step {
+    instanceId = processTestHelper.getStartProcessApi().startProcess(
+      StartProcessByMessageAtElementCmd(
+        messageName = messageName,
         elementId = elementId,
         payloadSupplier = { emptyMap() },
       )

--- a/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseThenStage.kt
+++ b/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseThenStage.kt
@@ -40,6 +40,14 @@ class BaseThenStage : Stage<BaseThenStage>() {
     assertThat(process).isNotNull()
   }
 
+  fun `we should have an active token in element`(elementId: String) = step {
+    await().untilAsserted {
+      assertThat(processTestHelper.getActiveElements(instanceId))
+        .describedAs("Process %s has no active token in element %s", instanceId, elementId)
+        .contains(elementId)
+    }
+  }
+
   fun `we should get notified about a new user task with pull strategy`() = step {
     processTestHelper.triggerPullingUserTaskDeliveryManually()
 

--- a/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/ProcessTestHelper.kt
+++ b/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/ProcessTestHelper.kt
@@ -27,6 +27,8 @@ interface ProcessTestHelper {
 
   fun getProcessInformation(instanceId: String): ProcessInformation
 
+  fun getActiveElements(instanceId: String): Collection<String>
+
   fun clearAllSubscriptions()
 
 }

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImpl.kt
@@ -89,6 +89,23 @@ class StartProcessApiImpl(
           instance
         }
 
+      is StartProcessByMessageAtElementCmd ->
+        commandExecutor.execute {
+          logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-007: starting a new process instance by message ${cmd.messageName} at element ${cmd.elementId}" }
+          val startProcessCommand = StartProcessByMessageCmd(
+            messageName = cmd.messageName,
+            payloadSupplier = cmd.payloadSupplier,
+            restrictions = cmd.restrictions,
+          )
+          val instance = this.startProcess(startProcessCommand).get()
+          val processDefinitionId = instance.meta[CommonRestrictions.PROCESS_DEFINITION_KEY] as String
+          runtimeService.createModification(processDefinitionId)
+            .processInstanceIds(instance.instanceId)
+            .startBeforeActivity(cmd.elementId)
+            .execute()
+          instance
+        }
+
       else -> throw IllegalArgumentException("Unsupported start command $cmd")
     }
   }

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/C7EmbeddedProcessTestHelper.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/C7EmbeddedProcessTestHelper.kt
@@ -106,6 +106,9 @@ class C7EmbeddedProcessTestHelper(private val processEngine: ProcessEngine) : Pr
       .singleResult()
       .toProcessInformation()
 
+  override fun getActiveElements(instanceId: String): Collection<String> =
+    processEngine.runtimeService.getActiveActivityIds(instanceId)
+
   override fun clearAllSubscriptions() = subscriptionRepository.deleteAllTaskSubscriptions()
 
 

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/C7EmbeddedStartProcessApiITest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/C7EmbeddedStartProcessApiITest.kt
@@ -69,5 +69,6 @@ class C7EmbeddedStartProcessApiITest : AbstractC7EmbeddedApiITest(C7EmbeddedProc
 
     THEN
       .`we should have a running process`()
+      .`we should have an active token in element`("service-do-action2")
   }
 }

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/C7EmbeddedStartProcessApiITest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/C7EmbeddedStartProcessApiITest.kt
@@ -61,4 +61,13 @@ class C7EmbeddedStartProcessApiITest : AbstractC7EmbeddedApiITest(C7EmbeddedProc
     THEN
       .`we should have a running process`()
   }
+
+  @Test
+  fun `should start process at element via message`() {
+    WHEN
+      .`start process by message at element`(START_MESSAGE, "service-do-action2")
+
+    THEN
+      .`we should have a running process`()
+  }
 }

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImplTest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImplTest.kt
@@ -4,6 +4,7 @@ import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.adapter.c7.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
 import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.RuntimeService
@@ -154,9 +155,7 @@ class StartProcessApiImplTest {
     val businessKey = "myBusinessKey"
     val modificationBuilder = modifyProcessInstanceBuilderMock()
     val processDefinitionId = "simple-process:1:123"
-    val processInstance = ProcessInstanceFake.builder().id("instance-123")
-      .processDefinitionId(processDefinitionId)
-      .build()
+    val processInstance = processInstanceMock(processDefinitionId)
 
     whenever(runtimeService.startProcessInstanceByKey(anyString(), anyOrNull(), anyMap())).thenReturn(processInstance)
     whenever(runtimeService.createModification(processDefinitionId)).thenReturn(modificationBuilder)
@@ -176,6 +175,44 @@ class StartProcessApiImplTest {
     verify(modificationBuilder).startBeforeActivity("user-perform-task")
     verify(modificationBuilder).execute()
   }
+
+  @Test
+  fun `should start process at element via message without payload`() {
+
+    // given
+    val modificationBuilder = modifyProcessInstanceBuilderMock()
+    val processDefinitionId = "simple-process:1:123"
+    val processInstance = processInstanceMock(processDefinitionId)
+
+    val correlationBuilder: MessageCorrelationBuilder = mock()
+    whenever(correlationBuilder.setVariables(anyMap())).thenReturn(correlationBuilder)
+    whenever(correlationBuilder.correlateStartMessage()).thenReturn(processInstance)
+    whenever(runtimeService.createMessageCorrelation(any())).thenReturn(correlationBuilder)
+    whenever(runtimeService.createModification(processDefinitionId)).thenReturn(modificationBuilder)
+
+    val cmd = StartProcessByMessageAtElementCmd(
+      messageName = "startMessage",
+      elementId = "user-perform-task",
+      payloadSupplier = { emptyMap() }
+    )
+
+    // when
+    startProcessApi.startProcess(cmd).get()
+
+    // then
+    verify(runtimeService).createMessageCorrelation("startMessage")
+    verify(correlationBuilder).setVariables(emptyMap())
+    verify(runtimeService).createModification(processDefinitionId)
+    verify(modificationBuilder).processInstanceIds("instance-123")
+    verify(modificationBuilder).startBeforeActivity("user-perform-task")
+    verify(modificationBuilder).execute()
+  }
+
+  private fun processInstanceMock(processDefinitionId: String): ProcessInstance =
+    ProcessInstanceFake.builder()
+      .id("instance-123")
+      .processDefinitionId(processDefinitionId)
+      .build()
 
   private fun messageCorrelationMock(): MessageCorrelationBuilder {
     val builder: MessageCorrelationBuilder = mock()

--- a/engine-adapter/c7-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/C7EmbeddedSpringProcessTestHelper.kt
+++ b/engine-adapter/c7-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/C7EmbeddedSpringProcessTestHelper.kt
@@ -45,6 +45,9 @@ class C7EmbeddedSpringProcessTestHelper(
       .singleResult()
       .toProcessInformation()
 
+  override fun getActiveElements(instanceId: String): Collection<String> =
+    runtimeService.getActiveActivityIds(instanceId)
+
   override fun clearAllSubscriptions() = (subscriptionRepository as InMemSubscriptionRepository).deleteAllTaskSubscriptions()
 
 }

--- a/engine-adapter/c7-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/C7EmbeddedSpringStartProcessApiITest.kt
+++ b/engine-adapter/c7-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/C7EmbeddedSpringStartProcessApiITest.kt
@@ -62,6 +62,7 @@ class C7EmbeddedSpringStartProcessApiITest(
 
     THEN
       .`we should have a running process`()
+      .`we should have an active token in element`("service-do-action2")
   }
 
 }

--- a/engine-adapter/c7-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/C7EmbeddedSpringStartProcessApiITest.kt
+++ b/engine-adapter/c7-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/springboot/C7EmbeddedSpringStartProcessApiITest.kt
@@ -55,4 +55,13 @@ class C7EmbeddedSpringStartProcessApiITest(
       .`we should have a running process`()
   }
 
+  @Test
+  fun `should start process at element via message`() {
+    WHEN
+      .`start process by message at element`(START_MESSAGE, "service-do-action2")
+
+    THEN
+      .`we should have a running process`()
+  }
+
 }

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImpl.kt
@@ -9,6 +9,7 @@ import dev.bpmcrafters.processengineapi.process.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.community.rest.client.api.MessageApiClient
 import org.camunda.community.rest.client.api.ProcessDefinitionApiClient
+import org.camunda.community.rest.client.api.ProcessInstanceApiClient
 import org.camunda.community.rest.client.model.*
 import org.camunda.community.rest.variables.ValueMapper
 import java.util.concurrent.CompletableFuture
@@ -18,6 +19,7 @@ private val logger = KotlinLogging.logger {}
 class StartProcessApiImpl(
   private val processDefinitionApiClient: ProcessDefinitionApiClient,
   private val messageApiClient: MessageApiClient,
+  private val processInstanceApiClient: ProcessInstanceApiClient,
   private val processDefinitionMetaDataResolver: ProcessDefinitionMetaDataResolver,
   private val valueMapper: ValueMapper,
 ) : StartProcessApi {
@@ -95,6 +97,27 @@ class StartProcessApiImpl(
           val instance = processDefinitionApiClient.startProcessInstance(processDefinitionId, startProcessInstanceDto)
           val processInformation = instance.body?.toProcessInformation()
           requireNotNull(processInformation) { "Could not start process instance ${cmd.definitionKey}, resulting status was ${instance.statusCode}" }
+        }
+
+      is StartProcessByMessageAtElementCmd ->
+        CompletableFuture.supplyAsync {
+          logger.debug { "PROCESS-ENGINE-C7-REMOTE-007: starting a new process instance by message ${cmd.messageName} at element ${cmd.elementId}" }
+          val startProcessCommand = StartProcessByMessageCmd(
+            messageName = cmd.messageName,
+            payloadSupplier = cmd.payloadSupplier,
+            restrictions = cmd.restrictions,
+          )
+          val instance = this.startProcess(startProcessCommand).get()
+
+          val startInstructionDto = ProcessInstanceModificationInstructionDto()
+          startInstructionDto.type = ProcessInstanceModificationInstructionDto.TypeEnum.START_BEFORE_ACTIVITY
+          startInstructionDto.activityId = cmd.elementId
+
+          val modificationDto = ProcessInstanceModificationDto()
+          modificationDto.instructions(listOf(startInstructionDto))
+
+          processInstanceApiClient.modifyProcessInstance(instance.instanceId, modificationDto)
+          instance
         }
 
       else -> throw IllegalArgumentException("Unsupported start command $cmd")

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByDefinitionAtElementTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByDefinitionAtElementTest.kt
@@ -5,6 +5,7 @@ import dev.bpmcrafters.processengineapi.adapter.c7.remote.TestFixtures
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionAtElementCmd
 import org.camunda.community.rest.client.api.MessageApiClient
 import org.camunda.community.rest.client.api.ProcessDefinitionApiClient
+import org.camunda.community.rest.client.api.ProcessInstanceApiClient
 import org.camunda.community.rest.client.model.ProcessDefinitionDto
 import org.camunda.community.rest.client.model.ProcessInstanceModificationInstructionDto
 import org.camunda.community.rest.client.model.ProcessInstanceModificationInstructionDto.TypeEnum.START_BEFORE_ACTIVITY
@@ -28,6 +29,9 @@ class StartProcessApiImplByDefinitionAtElementTest {
   @Suppress("unused")
   private val messageApiClient: MessageApiClient = mock()
   private val processDefinitionApiClient: ProcessDefinitionApiClient = mock()
+
+  @Suppress("unused")
+  private val processInstanceApiClient: ProcessInstanceApiClient = mock()
 
   @Spy
   private val valueMapper: ValueMapper = TestFixtures.valueMapper()

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByDefinitionTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByDefinitionTest.kt
@@ -6,6 +6,7 @@ import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
 import org.assertj.core.api.Assertions.assertThat
 import org.camunda.community.rest.client.api.MessageApiClient
 import org.camunda.community.rest.client.api.ProcessDefinitionApiClient
+import org.camunda.community.rest.client.api.ProcessInstanceApiClient
 import org.camunda.community.rest.client.model.ProcessDefinitionDto
 import org.camunda.community.rest.client.model.ProcessInstanceWithVariablesDto
 import org.camunda.community.rest.client.model.StartProcessInstanceDto
@@ -27,6 +28,9 @@ class StartProcessApiImplByDefinitionTest {
 
   private val processDefinitionApiClient: ProcessDefinitionApiClient = mock()
   private val messageApiClient: MessageApiClient = mock()
+
+  @Suppress("unused")
+  private val processInstanceApiClient: ProcessInstanceApiClient = mock()
 
   @Spy
   private val valueMapper: ValueMapper = TestFixtures.valueMapper()

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByMessageAtElementTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByMessageAtElementTest.kt
@@ -1,0 +1,135 @@
+package dev.bpmcrafters.processengineapi.adapter.c7.remote.process
+
+import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.adapter.c7.remote.TestFixtures
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageAtElementCmd
+import org.camunda.community.rest.client.api.MessageApiClient
+import org.camunda.community.rest.client.api.ProcessDefinitionApiClient
+import org.camunda.community.rest.client.api.ProcessInstanceApiClient
+import org.camunda.community.rest.client.model.CorrelationMessageDto
+import org.camunda.community.rest.client.model.MessageCorrelationResultWithVariableDto
+import org.camunda.community.rest.client.model.ProcessInstanceDto
+import org.camunda.community.rest.client.model.ProcessInstanceModificationDto
+import org.camunda.community.rest.client.model.ProcessInstanceModificationInstructionDto
+import org.camunda.community.rest.client.model.ProcessInstanceModificationInstructionDto.TypeEnum.START_BEFORE_ACTIVITY
+import org.camunda.community.rest.variables.ValueMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mockito.*
+import org.mockito.Spy
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.ResponseEntity
+
+@ExtendWith(MockitoExtension::class)
+class StartProcessApiImplByMessageAtElementTest {
+
+  @Suppress("unused")
+  private val processDefinitionApiClient: ProcessDefinitionApiClient = mock()
+  private val messageApiClient: MessageApiClient = mock()
+  private val processInstanceApiClient: ProcessInstanceApiClient = mock()
+
+  @Spy
+  private val valueMapper: ValueMapper = TestFixtures.valueMapper()
+
+  @Spy
+  @Suppress("unused")
+  private val processDefinitionMetaDataResolver = CachingProcessDefinitionMetaDataResolver(
+    processDefinitionApiClient
+  )
+
+  @InjectMocks
+  private lateinit var startProcessApi: StartProcessApiImpl
+
+  @BeforeEach
+  fun `setup mock`() {
+
+    val message = MessageCorrelationResultWithVariableDto().processInstance(
+      ProcessInstanceDto()
+        .id("instanceId")
+        .definitionKey("definitionKey")
+        .definitionId("definitionId")
+        .tenantId("tenantId")
+    )
+
+    whenever(messageApiClient.deliverMessage(any())).thenReturn(
+      ResponseEntity.ok(listOf(message))
+    )
+  }
+
+  @Test
+  fun `should start process at element via message without payload`() {
+
+    // given
+    val startProcessByMessageAtElementCmd = StartProcessByMessageAtElementCmd(
+      messageName = "startMessage",
+      elementId = "myActivity",
+      payloadSupplier = { emptyMap() },
+      restrictions = mapOf()
+    )
+
+    // when
+    startProcessApi.startProcess(startProcessByMessageAtElementCmd).get()
+
+    // then
+    verify(messageApiClient).deliverMessage(
+      CorrelationMessageDto()
+        .messageName("startMessage")
+        .processVariables(valueMapper.mapValues(mapOf()))
+        .resultEnabled(true)
+    )
+    verify(processInstanceApiClient).modifyProcessInstance(
+      "instanceId",
+      ProcessInstanceModificationDto().apply {
+        this.instructions = listOf(
+          ProcessInstanceModificationInstructionDto().apply {
+            this.type = START_BEFORE_ACTIVITY
+            this.activityId = "myActivity"
+          }
+        )
+      }
+    )
+  }
+
+  @Test
+  fun `should start process at element via message with payload, business key and tenant`() {
+
+    // given
+    val payload = mapOf("key" to "value", CommonRestrictions.BUSINESS_KEY to "businessKey")
+    val startProcessByMessageAtElementCmd = StartProcessByMessageAtElementCmd(
+      messageName = "startMessage",
+      elementId = "serviceTask1",
+      payloadSupplier = { payload },
+      restrictions = mapOf(CommonRestrictions.TENANT_ID to "tenantId")
+    )
+
+    // when
+    startProcessApi.startProcess(startProcessByMessageAtElementCmd).get()
+
+    // then
+    verify(messageApiClient).deliverMessage(
+      CorrelationMessageDto()
+        .messageName("startMessage")
+        .businessKey("businessKey")
+        .processVariables(valueMapper.mapValues(payload))
+        .resultEnabled(true)
+        .tenantId("tenantId")
+    )
+    verify(processInstanceApiClient).modifyProcessInstance(
+      "instanceId",
+      ProcessInstanceModificationDto().apply {
+        this.instructions = listOf(
+          ProcessInstanceModificationInstructionDto().apply {
+            this.type = START_BEFORE_ACTIVITY
+            this.activityId = "serviceTask1"
+          }
+        )
+      }
+    )
+  }
+
+}

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByMessageTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplByMessageTest.kt
@@ -6,6 +6,7 @@ import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
 import org.assertj.core.api.Assertions.assertThat
 import org.camunda.community.rest.client.api.MessageApiClient
 import org.camunda.community.rest.client.api.ProcessDefinitionApiClient
+import org.camunda.community.rest.client.api.ProcessInstanceApiClient
 import org.camunda.community.rest.client.model.*
 import org.camunda.community.rest.variables.ValueMapper
 import org.junit.jupiter.api.BeforeEach
@@ -25,6 +26,9 @@ class StartProcessApiImplByMessageTest {
 
   private val processDefinitionApiClient: ProcessDefinitionApiClient = mock()
   private val messageApiClient: MessageApiClient = mock()
+
+  @Suppress("unused")
+  private val processInstanceApiClient: ProcessInstanceApiClient = mock()
 
   @Spy
   private val valueMapper: ValueMapper = TestFixtures.valueMapper()

--- a/engine-adapter/c7-remote-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteAdapterAutoConfiguration.kt
+++ b/engine-adapter/c7-remote-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteAdapterAutoConfiguration.kt
@@ -60,11 +60,13 @@ class C7RemoteAdapterAutoConfiguration {
   fun startProcessApi(
     processDefinitionApiClient: ProcessDefinitionApiClient,
     messageApiClient: MessageApiClient,
+    processInstanceApiClient: ProcessInstanceApiClient,
     valueMapper: ValueMapper,
     processDefinitionMetaDataResolver: ProcessDefinitionMetaDataResolver,
   ): StartProcessApi = StartProcessApiImpl(
     processDefinitionApiClient = processDefinitionApiClient,
     messageApiClient = messageApiClient,
+    processInstanceApiClient = processInstanceApiClient,
     processDefinitionMetaDataResolver = processDefinitionMetaDataResolver,
     valueMapper = valueMapper
   )

--- a/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteProcessTestHelper.kt
+++ b/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteProcessTestHelper.kt
@@ -15,6 +15,7 @@ import dev.bpmcrafters.processengineapi.task.TaskSubscriptionApi
 import dev.bpmcrafters.processengineapi.task.UserTaskCompletionApi
 import dev.bpmcrafters.processengineapi.test.ProcessTestHelper
 import org.camunda.community.rest.client.api.ProcessInstanceApiClient
+import org.camunda.community.rest.client.model.ActivityInstanceDto
 
 class C7RemoteProcessTestHelper(
   private val startProcessApi: StartProcessApi,
@@ -52,6 +53,22 @@ class C7RemoteProcessTestHelper(
       .getProcessInstance(instanceId)
       .body!!.toProcessInformation()
 
+
+  override fun getActiveElements(instanceId: String): Collection<String> {
+    val tree = processInstanceApiClient.getActivityInstanceTree(instanceId).body ?: return emptyList()
+    return tree.collectActiveElements()
+  }
+
+  /**
+   * Flattens the activity instance tree into the element ids that currently hold a token.
+   * The root node represents the process instance itself and is therefore skipped; only the
+   * descendant activity instances (and transition instances, i.e. async-before/after tokens) count.
+   */
+  private fun ActivityInstanceDto.collectActiveElements(isRoot: Boolean = true): List<String> {
+    val children = (childActivityInstances ?: emptyList()).flatMap { it.collectActiveElements(isRoot = false) }
+    val transitions = (childTransitionInstances ?: emptyList()).mapNotNull { it.activityId }
+    return if (isRoot) children + transitions else listOf(activityId) + children + transitions
+  }
 
   override fun clearAllSubscriptions() {
     (subscriptionRepository as InMemSubscriptionRepository).deleteAllTaskSubscriptions()

--- a/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteStartProcessApiITest.kt
+++ b/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteStartProcessApiITest.kt
@@ -53,4 +53,13 @@ class C7RemoteStartProcessApiITest : AbstractC7RemoteApiITestBase() {
       .`we should have a running process`()
   }
 
+  @Test
+  fun `should start process at element via message`() {
+    WHEN
+      .`start process by message at element`(START_MESSAGE, "service-do-action2")
+
+    THEN
+      .`we should have a running process`()
+  }
+
 }

--- a/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteStartProcessApiITest.kt
+++ b/engine-adapter/c7-remote-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/springboot/C7RemoteStartProcessApiITest.kt
@@ -60,6 +60,7 @@ class C7RemoteStartProcessApiITest : AbstractC7RemoteApiITestBase() {
 
     THEN
       .`we should have a running process`()
+      .`we should have an active token in element`("service-do-action2")
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <!-- COMMON GLOBAL -->
     <spring-boot.version>3.5.15</spring-boot.version>
-    <process-engine-api.version>1.6</process-engine-api.version>
+    <process-engine-api.version>1.7</process-engine-api.version>
     <c7.version>2026.04.2</c7.version>
     <!-- TEST -->
     <mockito.version>6.3.0</mockito.version>


### PR DESCRIPTION
## What

Implements `StartProcessByMessageAtElementCmd` for the Camunda 7 **embedded** and **remote** adapters, analogous to the existing `StartProcessByDefinitionAtElementCmd`.

It starts a process at a specific element via a **message name** (instead of a definition key) using the start-then-modify pattern:
1. correlate the start message to create the instance, then
2. modify the instance to start a token before the target element.

This covers processes that have **no plain (none) start event** and are entered only via one or multiple message start events (e.g. for testing a subpath).

## Changes

- **adapter-testing**: new `start process by message at element` JGiven stage.
- **c7-embedded-core**: new command branch — reuse the existing message correlation, then `runtimeService.createModification(...).startBeforeActivity(...)`.
- **c7-remote-core**: new command branch — correlate via `MessageApiClient`, then `ProcessInstanceApiClient.modifyProcessInstance(...)` with a `START_BEFORE_ACTIVITY` instruction. `ProcessInstanceApiClient` was added to `StartProcessApiImpl`'s constructor (and wired in `C7RemoteAdapterAutoConfiguration`); the existing remote `@InjectMocks` tests got the new mock.
- **Tests**: embedded unit + integration, remote unit + integration — coverage analogous to the definition-at-element command.
- **pom**: bump `process-engine-api` `1.6` → `1.7` (`StartProcessByMessageAtElementCmd`, `@since 1.7`).

## ⚠️ Dependency / CI note

Depends on **process-engine-api 1.7** (bpm-crafters/process-engine-api#293 — merged, milestone 1.7), which is **not yet released to Maven Central**. Until 1.7 is published, the build/CI cannot resolve the dependency and will be **red**. The adapter code and all tests were verified fully green locally against the identical `1.7-SNAPSHOT`, so the build goes green once 1.7 ships — no further changes needed.

**Do not merge before process-engine-api 1.7 is released.**

Closes #199
