### PR TITLE
Fix task sync inconsistency on error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## 1. Overview
+
+This repository contains the Camunda 7 implementation of the BPM Crafters Process Engine Adapter API. It is organized as a Maven multi-module workspace with library modules, Spring Boot starters, shared test support, and runnable examples.
+
+## 2. Folder Structure
+
+- `.github`: GitHub workflow and issue template configuration for CI and repository hygiene.
+- `.mvn`: Maven wrapper support files used by `./mvnw`.
+- `bom`: Maven BOM module publishing aligned dependency versions for consumers of the adapter.
+- `docs`: user-facing adapter documentation, including quickstarts and embedded/remote reference guides.
+- `engine-adapter`: main library modules.
+  - `adapter-testing`: shared Kotlin test support and JGiven-based integration test utilities.
+  - `c7-embedded-core`: embedded Camunda 7 adapter implementation, grouped by concerns such as process, task, decision, deploy, correlation, and shared engine helpers.
+  - `c7-embedded-spring-boot-starter`: Spring Boot auto-configuration and scheduling/bootstrap wiring for the embedded adapter.
+  - `c7-remote-core`: remote Camunda 7 adapter implementation, mirroring the embedded core structure where possible.
+  - `c7-remote-spring-boot-starter`: Spring Boot auto-configuration, client wiring, and polling/subscription setup for the remote adapter.
+- `examples`: runnable sample applications and shared example code.
+  - `java-common-fixture`: shared Java example domain, ports, adapters, controllers, and task handlers.
+  - `java-c7-embedded`: embedded example application and tests.
+  - `java-c7-remote`: remote example application.
+  - `java-c7-remote-sb4`: remote example variant for newer Spring Boot setup.
+- `mvnw`: project Maven wrapper entrypoint.
+- `pom.xml`: root aggregator POM, shared dependency management, build plugin defaults, and example profile activation.
+
+Ignore generated build output under `target/`; those directories are checked into the working tree only as build artifacts and are not source locations for edits.
+
+## 3. Working Agreements
+
+- Respond in English; keep Java, Kotlin, Maven, Spring Boot, Camunda, and API terms in English.
+- Before editing, inspect the matching embedded/remote or core/starter counterpart so changes follow existing symmetry instead of drifting module behavior.
+- Prefer small, module-scoped changes; do not introduce new abstraction layers or compatibility shims unless the task explicitly requires them.
+- Place new code beside the existing concern-based packages and follow established suffixes such as `*ApiImpl`, `*AutoConfiguration`, `*Properties`, `*Condition`, `*ITest`, and `*Test`.
+- Do not edit `target/` outputs or vendored example web assets unless the task is explicitly about generated/static resources.
+- Do not add tests, lint tasks, or formatting-only churn unless the user asks for them; when behavior spans mirrored modules, verify whether both sides need the same change.
+- Add comments only for non-obvious invariants or engine-specific behavior; keep them short and factual.
+- Ask for clarification when the target surface is ambiguous, especially whether work belongs in the published adapter modules, Spring Boot starters, shared test utilities, or examples.

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
@@ -130,7 +130,7 @@ class EmbeddedPullServiceTaskDelivery(
           logger.error { "PROCESS-ENGINE-C7-EMBEDDED-033: failing delivering task ${lockedTask.id}: ${e.message}" }
           metrics.incrementFailedTasksCounter(lockedTask.topicName!!)
           externalTaskService.handleFailure(lockedTask.id, workerId, e.message, jobRetries, retryTimeoutInSeconds * 1000)
-          subscriptionRepository.deactivateSubscriptionForTask(taskId = lockedTask.id)
+          cleanupFailedDelivery(lockedTask.id)
           logger.error { "PROCESS-ENGINE-C7-EMBEDDED-034: successfully failed delivering task ${lockedTask.id}: ${e.message}" }
 
         } finally {
@@ -184,6 +184,19 @@ class EmbeddedPullServiceTaskDelivery(
         ).withReason(TaskInformation.DELETE)
       )
       metrics.incrementTerminatedTasksCounter(taskSubscriptionHandle.taskDescriptionKey ?: "?")
+    }
+  }
+
+  private fun cleanupFailedDelivery(taskId: String) {
+    val taskSubscriptionHandle = subscriptionRepository.deactivateSubscriptionForTask(taskId = taskId)
+    if (taskSubscriptionHandle != null) {
+      try {
+        taskSubscriptionHandle.termination.accept(
+          TaskInformation(taskId = taskId, meta = emptyMap()).withReason(TaskInformation.DELETE)
+        )
+      } catch (terminationError: Exception) {
+        logger.error { "PROCESS-ENGINE-C7-EMBEDDED-046: failed cleaning up delivery state for task $taskId: ${terminationError.message}" }
+      }
     }
   }
 

--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullUserTaskDelivery.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullUserTaskDelivery.kt
@@ -30,112 +30,130 @@ class EmbeddedPullUserTaskDelivery(
 ) : UserTaskDelivery, RefreshableDelivery {
 
   private val deliveredTasks: ConcurrentHashMap<String, TaskInformation> = ConcurrentHashMap()
+  private val refreshLock = Any()
 
   /**
    * Delivers all tasks found in user task service to corresponding subscriptions.
    */
   override fun refresh() {
-    val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
-    if (subscriptions.isNotEmpty()) {
-      val deliveredTaskIds = subscriptionRepository.getDeliveredTaskIds(TaskType.USER).toMutableList()
-      // clean up task information items which are not in the list of delivered task ids. This is because,
-      // if a task has been completed via API and the list of delivered tasks is reduced, the `deliveredTasks`
-      // variable has not been updated yet.
-      synchronized(deliveredTasks) {
-        (deliveredTasks.keys().asSequence().filterNot { deliveredTaskIds.contains(it) }).forEach(deliveredTasks::remove)
-      }
+    synchronized(refreshLock) {
+      val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
+      if (subscriptions.isNotEmpty()) {
+        val deliveredTaskIds = subscriptionRepository.getDeliveredTaskIds(TaskType.USER).toMutableList()
+        // clean up task information items which are not in the list of delivered task ids. This is because,
+        // if a task has been completed via API and the list of delivered tasks is reduced, the `deliveredTasks`
+        // variable has not been updated yet.
+        synchronized(deliveredTasks) {
+          (deliveredTasks.keys().asSequence().filterNot { deliveredTaskIds.contains(it) }).forEach(deliveredTasks::remove)
+        }
 
-      logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-036: pulling user tasks for subscriptions: $subscriptions" }
-      taskService
-        .createTaskQuery()
-        .initializeFormKeys()
-        .forSubscriptions(subscriptions)
-        .list()
-        .asSequence()
-        .mapNotNull { task ->
-          subscriptions
-            .firstOrNull { subscription -> subscription.matches(task) }
-            ?.let { activeSubscription: TaskSubscriptionHandle ->
-              executorService.submit {  // in another thread
-                try {
-                  val processDefinitionKey = processDefinitionMetaDataResolver.getProcessDefinitionKey(task.processDefinitionId)
-                  val candidates = taskService.getIdentityLinksForTask(task.id).toSet()
-                  // create task information and set up the reason
-                  val taskInformation =
-                    if (deliveredTaskIds.contains(task.id)
-                      && subscriptionRepository.getActiveSubscriptionForTask(task.id) == activeSubscription
-                    ) {
-                      // task was already delivered to this subscription
-                      if (task.hasChanged()) {
-                        if (task.hasChangedAssignees(candidates)) {
-                          task.toTaskInformation(candidates, processDefinitionKey).withReason(TaskInformation.ASSIGN)
+        logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-036: pulling user tasks for subscriptions: $subscriptions" }
+        taskService
+          .createTaskQuery()
+          .initializeFormKeys()
+          .forSubscriptions(subscriptions)
+          .list()
+          .asSequence()
+          .mapNotNull { task ->
+            subscriptions
+              .firstOrNull { subscription -> subscription.matches(task) }
+              ?.let { activeSubscription: TaskSubscriptionHandle ->
+                executorService.submit {  // in another thread
+                  try {
+                    val processDefinitionKey = processDefinitionMetaDataResolver.getProcessDefinitionKey(task.processDefinitionId)
+                    val candidates = taskService.getIdentityLinksForTask(task.id).toSet()
+                    // create task information and set up the reason
+                    val taskInformation =
+                      if (deliveredTaskIds.contains(task.id)
+                        && subscriptionRepository.getActiveSubscriptionForTask(task.id) == activeSubscription
+                      ) {
+                        // task was already delivered to this subscription
+                        if (task.hasChanged()) {
+                          if (task.hasChangedAssignees(candidates)) {
+                            task.toTaskInformation(candidates, processDefinitionKey).withReason(TaskInformation.ASSIGN)
+                          } else {
+                            task.toTaskInformation(candidates, processDefinitionKey).withReason(TaskInformation.UPDATE)
+                          }
                         } else {
-                          task.toTaskInformation(candidates, processDefinitionKey).withReason(TaskInformation.UPDATE)
+                          // no change on the task
+                          null
                         }
+
                       } else {
-                        // no change on the task
-                        null
+                        // task is new for this subscription
+                        task.toTaskInformation(candidates, processDefinitionKey).withReason(TaskInformation.CREATE)
                       }
-
+                    if (taskInformation != null) {
+                      subscriptionRepository.activateSubscriptionForTask(task.id, activeSubscription)
+                      synchronized(deliveredTasks) {
+                        deliveredTasks[task.id] = taskInformation
+                      }
+                      val variables = taskService.getVariables(task.id).filterBySubscription(activeSubscription)
+                      logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-037: delivering user task ${task.id}." }
+                      activeSubscription.action.accept(taskInformation, variables)
                     } else {
-                      // task is new for this subscription
-                      task.toTaskInformation(candidates, processDefinitionKey).withReason(TaskInformation.CREATE)
+                      logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-040: skipping task ${task.id} since it is unchanged." }
                     }
-                  if (taskInformation != null) {
-                    subscriptionRepository.activateSubscriptionForTask(task.id, activeSubscription)
-                    synchronized(deliveredTasks) {
-                      deliveredTasks[task.id] = taskInformation
-                    }
-                    val variables = taskService.getVariables(task.id).filterBySubscription(activeSubscription)
-                    logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-037: delivering user task ${task.id}." }
-                    activeSubscription.action.accept(taskInformation, variables)
-                  } else {
-                    logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-040: skipping task ${task.id} since it is unchanged." }
-                  }
-                  // successfully handled the task, remove from already delivered
-                  // since we do it from another thread, this must terminate before
-                  // we can access the `deliveredTaskIds` for
-                  synchronized(deliveredTaskIds) {
-                    if (deliveredTaskIds.contains(task.id)) { // if the task was already there, remove it from unprocessed list
-                      val successful = deliveredTaskIds.remove(task.id)
-                      if (!successful) {
-                        logger.error { "PROCESS-ENGINE-C7-EMBEDDED-038: error processing task ${task.id}, could not mark updated task as processed." }
+                  } catch (e: Exception) {
+                    logger.error(e) { "PROCESS-ENGINE-C7-EMBEDDED-038: error delivering task ${task.id}: ${e.message}" }
+                    cleanupFailedDelivery(task.id)
+                  } finally {
+                    // The task still exists in the engine because it was returned by the query.
+                    // Remove it from the stale snapshot even if processing failed.
+                    synchronized(deliveredTaskIds) {
+                      if (deliveredTaskIds.contains(task.id)) { // if the task was already there, remove it from unprocessed list
+                        val successful = deliveredTaskIds.remove(task.id)
+                        if (!successful) {
+                          logger.error { "PROCESS-ENGINE-C7-EMBEDDED-038: error processing task ${task.id}, could not mark updated task as processed." }
+                        }
                       }
                     }
                   }
-
-                } catch (e: Exception) {
-                  logger.error { "PROCESS-ENGINE-C7-EMBEDDED-038: error delivering task ${task.id}: ${e.message}" }
-                  subscriptionRepository.deactivateSubscriptionForTask(taskId = task.id)
                 }
               }
-            }
-        }.forEach { taskExecutionFuture ->
-          taskExecutionFuture.get() // finish all before submitting the de-activation
-        }
-
-      // now we removed all still existing task ids from the list of already delivered
-      // the remaining tasks doesn't exist in the engine, lets handle them
-      deliveredTaskIds
-        .parallelStream()
-        .map { taskId ->
-          executorService.submit { // also async
-            // deactivate active subscription and handle termination
-            logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-042: deactivating $taskId, task is gone." }
-            subscriptionRepository.deactivateSubscriptionForTask(taskId)
-              ?.termination
-              ?.accept(
-                TaskInformation(taskId = taskId, meta = emptyMap()).withReason(TaskInformation.DELETE)
-              )
-            synchronized(deliveredTasks) {
-              deliveredTasks.remove(taskId)
-            }
+          }.forEach { taskExecutionFuture ->
+            taskExecutionFuture.get() // finish all before submitting the de-activation
           }
-        }.forEach { terminationExecutionFuture ->
-          terminationExecutionFuture.get() // finish this thread too
-        }
-    } else {
-      logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-039: pull user tasks disabled because of no active subscriptions" }
+
+        // now we removed all still existing task ids from the list of already delivered
+        // the remaining tasks doesn't exist in the engine, lets handle them
+        deliveredTaskIds
+          .parallelStream()
+          .map { taskId ->
+            executorService.submit { // also async
+              // deactivate active subscription and handle termination
+              logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-042: deactivating $taskId, task is gone." }
+              subscriptionRepository.deactivateSubscriptionForTask(taskId)
+                ?.termination
+                ?.accept(
+                  TaskInformation(taskId = taskId, meta = emptyMap()).withReason(TaskInformation.DELETE)
+                )
+              synchronized(deliveredTasks) {
+                deliveredTasks.remove(taskId)
+              }
+            }
+          }.forEach { terminationExecutionFuture ->
+            terminationExecutionFuture.get() // finish this thread too
+          }
+      } else {
+        logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-039: pull user tasks disabled because of no active subscriptions" }
+      }
+    }
+  }
+
+  private fun cleanupFailedDelivery(taskId: String) {
+    val activeSubscription = subscriptionRepository.deactivateSubscriptionForTask(taskId = taskId)
+    synchronized(deliveredTasks) {
+      deliveredTasks.remove(taskId)
+    }
+    if (activeSubscription != null) {
+      try {
+        activeSubscription.termination.accept(
+          TaskInformation(taskId = taskId, meta = emptyMap()).withReason(TaskInformation.DELETE)
+        )
+      } catch (terminationError: Exception) {
+        logger.error(terminationError) { "PROCESS-ENGINE-C7-EMBEDDED-044: error cleaning up failed delivery for task $taskId: ${terminationError.message}" }
+      }
     }
   }
 
@@ -192,4 +210,3 @@ class EmbeddedPullUserTaskDelivery(
         }
       }
 }
-

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDeliveryTest.kt
@@ -2,17 +2,25 @@ package dev.bpmcrafters.processengineapi.adapter.c7.embedded.task.delivery.pull
 
 import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
+import dev.bpmcrafters.processengineapi.task.TaskInformation
 import dev.bpmcrafters.processengineapi.task.TaskType
 import org.assertj.core.api.Assertions.assertThat
+import org.camunda.bpm.engine.ExternalTaskService
 import org.camunda.bpm.engine.externaltask.LockedExternalTask
+import org.camunda.bpm.engine.variable.Variables
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.Date
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class EmbeddedPullServiceTaskDeliveryTest {
 
+  private val externalTaskService: ExternalTaskService = mock()
   private val taskDelivery = EmbeddedPullServiceTaskDelivery(
-    externalTaskService = mock(),
+    externalTaskService = externalTaskService,
     subscriptionRepository = mock(),
     executor = mock(),
     lockDurationInSeconds = 30,
@@ -57,5 +65,52 @@ internal class EmbeddedPullServiceTaskDeliveryTest {
     with(taskDelivery) {
       assertThat(subscription.matches(task)).isFalse()
     }
+  }
+
+  @Test
+  fun `failed delivery cleans up local state via termination handler`() {
+    val subscriptionRepository = mock<dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository>()
+    val delivery = EmbeddedPullServiceTaskDelivery(
+      externalTaskService = externalTaskService,
+      subscriptionRepository = subscriptionRepository,
+      executor = mock(),
+      lockDurationInSeconds = 30,
+      workerId = "worker",
+      maxTasks = 10,
+      retryTimeoutInSeconds = 60,
+      retries = 3,
+      metrics = mock()
+    )
+    val state = mutableMapOf<String, TaskInformation>()
+    val terminated = mutableListOf<TaskInformation>()
+    val task = mock<LockedExternalTask>()
+    whenever(task.id).thenReturn("1")
+    whenever(task.topicName).thenReturn("topic")
+    whenever(task.lockExpirationTime).thenReturn(Date(System.currentTimeMillis() + 20_000))
+    whenever(task.retries).thenReturn(2)
+    whenever(task.variables).thenReturn(Variables.createVariables())
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      restrictions = mapOf(),
+      taskDescriptionKey = "topic",
+      payloadDescription = null,
+      action = { taskInformation, _ ->
+        state[taskInformation.taskId] = taskInformation
+        throw RuntimeException("Something went wrong")
+      },
+      termination = { taskInformation ->
+        state.remove(taskInformation.taskId)
+        terminated.add(taskInformation)
+      }
+    )
+    whenever(subscriptionRepository.deactivateSubscriptionForTask("1")).thenReturn(subscription)
+
+    delivery.createTaskActionHandlerCallable(task, subscription).call()
+
+    assertTrue(state.isEmpty())
+    assertEquals(1, terminated.size)
+    assertEquals(TaskInformation.DELETE, terminated.single().meta[TaskInformation.REASON])
+    verify(externalTaskService).handleFailure("1", "worker", "Something went wrong", 1, 60_000)
+    verify(subscriptionRepository).deactivateSubscriptionForTask("1")
   }
 }

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullUserTaskDeliveryTest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullUserTaskDeliveryTest.kt
@@ -11,15 +11,18 @@ import dev.bpmcrafters.processengineapi.task.support.UserTaskSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.camunda.bpm.engine.TaskService
 import org.camunda.bpm.engine.task.Task
+import org.camunda.bpm.engine.task.TaskQuery
 import org.camunda.community.mockito.QueryMocks
 import org.camunda.community.mockito.task.TaskFake
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class EmbeddedPullUserTaskDeliveryTest {
 
@@ -155,6 +158,39 @@ internal class EmbeddedPullUserTaskDeliveryTest {
 
     // then
     assertThat(deliveredDirectly).isEmpty()
+  }
+
+  @Test
+  fun `failed downstream handler does not leak tasks into user task support`() {
+    val leakingTaskCount = 70
+    val taskQuery = mock<TaskQuery>()
+    val firstRefreshTasks = tasks.take(leakingTaskCount)
+    val userTaskSupport = UserTaskSupport()
+    val terminatedTasks = ConcurrentHashMap<String, String>()
+    val thrownTasks = AtomicInteger()
+
+    whenever(taskService.createTaskQuery()).thenReturn(taskQuery)
+    whenever(taskQuery.initializeFormKeys()).thenReturn(taskQuery)
+    whenever(taskQuery.active()).thenReturn(taskQuery)
+    whenever(taskQuery.list()).thenReturn(firstRefreshTasks, emptyList())
+
+    userTaskSupport.subscribe(taskSubscriptionApi = C7TaskSubscriptionApiImpl(subscriptionRepository), restrictions = mapOf(), payloadDescription = null)
+    userTaskSupport.addHandler { taskInformation, _ ->
+      thrownTasks.incrementAndGet()
+      throw IllegalStateException("boom for ${taskInformation.taskId}")
+    }
+    userTaskSupport.addTerminationHandler { taskInformation ->
+      terminatedTasks[taskInformation.taskId] = taskInformation.taskId
+    }
+
+    embeddedPullUserTaskDelivery.refresh()
+    repeat(3) {
+      embeddedPullUserTaskDelivery.refresh()
+    }
+
+    assertThat(thrownTasks.get()).isEqualTo(leakingTaskCount)
+    assertThat(userTaskSupport.getAllTasks()).isEmpty()
+    assertThat(terminatedTasks).hasSize(leakingTaskCount)
   }
 
   private fun randomTask() = TaskFake

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullServiceTaskDelivery.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullServiceTaskDelivery.kt
@@ -145,6 +145,7 @@ class PullServiceTaskDelivery(
             errorMessage = e.message
           }
         )
+        cleanupFailedDelivery(lockedTask.id!!)
         logger.error { "PROCESS-ENGINE-C7-REMOTE-034: successfully failed delivering task ${lockedTask.id}: ${e.message}" }
       } finally {
         metrics.recordTaskExecutionTime(lockedTask.topicName!!, Duration.between(start, OffsetDateTime.now()))
@@ -208,6 +209,19 @@ class PullServiceTaskDelivery(
         ).withReason(TaskInformation.DELETE)
       )
       metrics.incrementTerminatedTasksCounter(taskSubscriptionHandle.taskDescriptionKey ?: "?")
+    }
+  }
+
+  private fun cleanupFailedDelivery(taskId: String) {
+    val taskSubscriptionHandle = subscriptionRepository.deactivateSubscriptionForTask(taskId)
+    if (taskSubscriptionHandle != null) {
+      try {
+        taskSubscriptionHandle.termination.accept(
+          TaskInformation(taskId = taskId, meta = emptyMap()).withReason(TaskInformation.DELETE)
+        )
+      } catch (terminationError: Exception) {
+        logger.error { "PROCESS-ENGINE-C7-REMOTE-046: failed cleaning up delivery state for task $taskId: ${terminationError.message}" }
+      }
     }
   }
 

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullUserTaskDelivery.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullUserTaskDelivery.kt
@@ -32,116 +32,138 @@ class PullUserTaskDelivery(
 ) : UserTaskDelivery, RefreshableDelivery {
 
   private val deliveredTasks: ConcurrentHashMap<String, TaskInformation> = ConcurrentHashMap()
+  private val refreshLock = Any()
 
   /**
    * Delivers all tasks found in user task service to corresponding subscriptions.
    */
   override fun refresh() {
-    val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
-    if (subscriptions.isNotEmpty()) {
-      val deliveredTaskIds = subscriptionRepository.getDeliveredTaskIds(TaskType.USER).toMutableList()
-      // clean up task information items which are not in the list of delivered task ids. This is because,
-      // if a task has been completed via API and the list of delivered tasks is reduced, the `deliveredTasks`
-      // variable has not been updated yet.
-      synchronized(deliveredTasks) {
-        (deliveredTasks.keys().asSequence().filterNot { deliveredTaskIds.contains(it) }).forEach(deliveredTasks::remove)
-      }
+    synchronized(refreshLock) {
+      val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
+      if (subscriptions.isNotEmpty()) {
+        val deliveredTaskIds = subscriptionRepository.getDeliveredTaskIds(TaskType.USER).toMutableList()
+        // clean up task information items which are not in the list of delivered task ids. This is because,
+        // if a task has been completed via API and the list of delivered tasks is reduced, the `deliveredTasks`
+        // variable has not been updated yet.
+        synchronized(deliveredTasks) {
+          (deliveredTasks.keys().asSequence().filterNot { deliveredTaskIds.contains(it) }).forEach(deliveredTasks::remove)
+        }
 
-      logger.trace { "PROCESS-ENGINE-C7-REMOTE-036: pulling user tasks for subscriptions: $subscriptions" }
-      val result = taskApiClient
-        .queryTasks(0, Integer.MAX_VALUE, TaskQueryDto().forSubscriptions(subscriptions))
+        logger.trace { "PROCESS-ENGINE-C7-REMOTE-036: pulling user tasks for subscriptions: $subscriptions" }
+        val result = taskApiClient
+          .queryTasks(0, Integer.MAX_VALUE, TaskQueryDto().forSubscriptions(subscriptions))
 
-      val taskDtoList = requireNotNull(result.body) { "Could not fetch user tasks for subscriptions: $subscriptions, status code was ${result.statusCode}" }
+        val taskDtoList = requireNotNull(result.body) { "Could not fetch user tasks for subscriptions: $subscriptions, status code was ${result.statusCode}" }
 
-      taskDtoList
-        .asSequence()
-        .mapNotNull { task ->
-          subscriptions
-            .firstOrNull { subscription -> subscription.matches(task) }
-            ?.let { activeSubscription ->
-              executorService.submit {  // in another thread
-                try {
-                  val identityResult = taskApiClient.getIdentityLinks(task.id, null)
-                  val candidates =
-                    requireNotNull(identityResult.body) { "Could not retrieve identity links for task ${task.id}, status was ${identityResult.statusCode}" }.toSet()
+        taskDtoList
+          .asSequence()
+          .mapNotNull { task ->
+            subscriptions
+              .firstOrNull { subscription -> subscription.matches(task) }
+              ?.let { activeSubscription ->
+                executorService.submit {  // in another thread
+                  try {
+                    val identityResult = taskApiClient.getIdentityLinks(task.id, null)
+                    val candidates =
+                      requireNotNull(identityResult.body) { "Could not retrieve identity links for task ${task.id}, status was ${identityResult.statusCode}" }.toSet()
 
-                  // create task information and set up the reason
-                  val taskInformation =
-                    if (deliveredTaskIds.contains(task.id!!)
-                      && subscriptionRepository.getActiveSubscriptionForTask(task.id!!) == activeSubscription
-                    ) {
-                      // task was already delivered to this subscription
-                      if (task.hasChanged()) {
-                        if (task.hasChangedAssignees(candidates)) {
-                          task.toTaskInformation(candidates, processDefinitionMetaDataResolver).withReason(TaskInformation.ASSIGN)
+                    // create task information and set up the reason
+                    val taskInformation =
+                      if (deliveredTaskIds.contains(task.id!!)
+                        && subscriptionRepository.getActiveSubscriptionForTask(task.id!!) == activeSubscription
+                      ) {
+                        // task was already delivered to this subscription
+                        if (task.hasChanged()) {
+                          if (task.hasChangedAssignees(candidates)) {
+                            task.toTaskInformation(candidates, processDefinitionMetaDataResolver).withReason(TaskInformation.ASSIGN)
+                          } else {
+                            task.toTaskInformation(candidates, processDefinitionMetaDataResolver).withReason(TaskInformation.UPDATE)
+                          }
                         } else {
-                          task.toTaskInformation(candidates, processDefinitionMetaDataResolver).withReason(TaskInformation.UPDATE)
+                          // no change on the task
+                          null
                         }
                       } else {
-                        // no change on the task
-                        null
+                        // task is new for this subscription
+                        task.toTaskInformation(candidates, processDefinitionMetaDataResolver).withReason(TaskInformation.CREATE)
                       }
+                    if (taskInformation != null) {
+                      subscriptionRepository.activateSubscriptionForTask(task.id!!, activeSubscription)
+                      synchronized(deliveredTasks) {
+                        deliveredTasks[task.id!!] = taskInformation
+                      }
+                      val variableResult = taskApiClient.getTaskVariables(task.id, deserializeOnServer)
+                      val variables =
+                        requireNotNull(variableResult.body) { "Could not retrieve variables for task ${task.id}, status was ${variableResult.statusCode}" }
+                          .filterBySubscription(activeSubscription)
+                          .let { dtoList -> valueMapper.mapDtos(variables = dtoList, deserializeValues = true) }
+                      logger.debug { "PROCESS-ENGINE-C7-REMOTE-037: delivering user task ${task.id}." }
+                      activeSubscription.action.accept(taskInformation, variables)
                     } else {
-                      // task is new for this subscription
-                      task.toTaskInformation(candidates, processDefinitionMetaDataResolver).withReason(TaskInformation.CREATE)
+                      logger.trace { "PROCESS-ENGINE-C7-REMOTE-040: skipping task ${task.id} since it is unchanged." }
                     }
-                  if (taskInformation != null) {
-                    subscriptionRepository.activateSubscriptionForTask(task.id!!, activeSubscription)
-                    synchronized(deliveredTasks) {
-                      deliveredTasks[task.id!!] = taskInformation
-                    }
-                    val variableResult = taskApiClient.getTaskVariables(task.id, deserializeOnServer)
-                    val variables =
-                      requireNotNull(variableResult.body) { "Could not retrieve variables for task ${task.id}, status was ${variableResult.statusCode}" }
-                        .filterBySubscription(activeSubscription)
-                        .let { dtoList -> valueMapper.mapDtos(variables = dtoList, deserializeValues = true) }
-                    logger.debug { "PROCESS-ENGINE-C7-REMOTE-037: delivering user task ${task.id}." }
-                    activeSubscription.action.accept(taskInformation, variables)
-                  } else {
-                    logger.trace { "PROCESS-ENGINE-C7-REMOTE-040: skipping task ${task.id} since it is unchanged." }
-                  }
-                  // successfully handled the task, remove from already delivered
-                  // since we do it from another thread, this must terminate before
-                  // we can access the `deliveredTaskIds` for
-                  synchronized(deliveredTasks) {
-                    if (deliveredTaskIds.contains(task.id!!)) { // if the task was already there, remove it from unprocessed list
-                      val successful = deliveredTaskIds.remove(task.id!!)
-                      if (!successful) {
-                        logger.error { "PROCESS-ENGINE-C7-REMOTE-038: error processing task ${task.id}, could not mark updated task as processed." }
+                  } catch (e: Exception) {
+                    logger.error(e) { "PROCESS-ENGINE-C7-REMOTE-038: error delivering task ${task.id}: ${e.message}" }
+                    cleanupFailedDelivery(task.id!!, deliveredTasks, subscriptionRepository)
+                  } finally {
+                    // The task still exists in the engine because it was returned by the query.
+                    // Remove it from the stale snapshot even if processing failed.
+                    synchronized(deliveredTaskIds) {
+                      if (deliveredTaskIds.contains(task.id!!)) { // if the task was already there, remove it from unprocessed list
+                        val successful = deliveredTaskIds.remove(task.id!!)
+                        if (!successful) {
+                          logger.error { "PROCESS-ENGINE-C7-REMOTE-038: error processing task ${task.id}, could not mark updated task as processed." }
+                        }
                       }
                     }
                   }
-
-                } catch (e: Exception) {
-                  logger.error { "PROCESS-ENGINE-C7-REMOTE-038: error delivering task ${task.id}: ${e.message}" }
-                  subscriptionRepository.deactivateSubscriptionForTask(taskId = task.id!!)
                 }
               }
-            }
-        }.forEach { taskExecutionFuture ->
-          taskExecutionFuture.get()
-        }
-
-      // now we removed all still existing task ids from the list of already delivered
-      // the remaining tasks doesn't exist in the engine, lets handle them
-      deliveredTaskIds.parallelStream().map { taskId ->
-        executorService.submit {
-          // deactivate active subscription and handle termination
-          subscriptionRepository.deactivateSubscriptionForTask(taskId)?.termination?.accept(
-            TaskInformation(
-              taskId = taskId,
-              meta = emptyMap()
-            ).withReason(TaskInformation.DELETE)
-          )
-          // deactivate active subscription and handle termination
-          logger.trace { "PROCESS-ENGINE-C7-REMOTE-042: deactivating $taskId, task is gone." }
-          synchronized(deliveredTasks) {
-            deliveredTasks.remove(taskId)
+          }.forEach { taskExecutionFuture ->
+            taskExecutionFuture.get()
           }
-        }
-      }.forEach { taskTerminationFuture -> taskTerminationFuture.get() }
-    } else {
-      logger.trace { "PROCESS-ENGINE-C7-REMOTE-039: pull user tasks disabled because of no active subscriptions" }
+
+        // now we removed all still existing task ids from the list of already delivered
+        // the remaining tasks doesn't exist in the engine, lets handle them
+        deliveredTaskIds.parallelStream().map { taskId ->
+          executorService.submit {
+            // deactivate active subscription and handle termination
+            subscriptionRepository.deactivateSubscriptionForTask(taskId)?.termination?.accept(
+              TaskInformation(
+                taskId = taskId,
+                meta = emptyMap()
+              ).withReason(TaskInformation.DELETE)
+            )
+            // deactivate active subscription and handle termination
+            logger.trace { "PROCESS-ENGINE-C7-REMOTE-042: deactivating $taskId, task is gone." }
+            synchronized(deliveredTasks) {
+              deliveredTasks.remove(taskId)
+            }
+          }
+        }.forEach { taskTerminationFuture -> taskTerminationFuture.get() }
+      } else {
+        logger.trace { "PROCESS-ENGINE-C7-REMOTE-039: pull user tasks disabled because of no active subscriptions" }
+      }
+    }
+  }
+
+  private fun cleanupFailedDelivery(
+    taskId: String,
+    deliveredTasks: ConcurrentHashMap<String, TaskInformation>,
+    subscriptionRepository: SubscriptionRepository,
+  ) {
+    val activeSubscription = subscriptionRepository.deactivateSubscriptionForTask(taskId = taskId)
+    synchronized(deliveredTasks) {
+      deliveredTasks.remove(taskId)
+    }
+    if (activeSubscription != null) {
+      try {
+        activeSubscription.termination.accept(
+          TaskInformation(taskId = taskId, meta = emptyMap()).withReason(TaskInformation.DELETE)
+        )
+      } catch (terminationError: Exception) {
+        logger.error(terminationError) { "PROCESS-ENGINE-C7-REMOTE-045: error cleaning up failed delivery for task $taskId: ${terminationError.message}" }
+      }
     }
   }
 
@@ -199,4 +221,3 @@ class PullUserTaskDelivery(
         }
       }
 }
-

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingServiceTaskDelivery.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingServiceTaskDelivery.kt
@@ -59,7 +59,7 @@ class SubscribingServiceTaskDelivery(
                       jobRetries,
                       retryTimeoutInSeconds * 1000 // millis
                     )
-                    subscriptionRepository.deactivateSubscriptionForTask(taskId = externalTask.id)
+                    cleanupFailedDelivery(externalTask.id)
                     logger.error { "PROCESS-ENGINE-C7-REMOTE-034: successfully failed delivering task ${externalTask.id}: ${e.message}" }
                   }
                 } else {
@@ -127,6 +127,19 @@ class SubscribingServiceTaskDelivery(
       this
     }
     // FIXME -> consider complex tenant filtering
+  }
+
+  private fun cleanupFailedDelivery(taskId: String) {
+    val taskSubscriptionHandle = subscriptionRepository.deactivateSubscriptionForTask(taskId = taskId)
+    if (taskSubscriptionHandle != null) {
+      try {
+        taskSubscriptionHandle.termination.accept(
+          TaskInformation(taskId = taskId, meta = emptyMap()).withReason(TaskInformation.DELETE)
+        )
+      } catch (terminationError: Exception) {
+        logger.error { "PROCESS-ENGINE-C7-REMOTE-046: failed cleaning up delivery state for task $taskId: ${terminationError.message}" }
+      }
+    }
   }
 
 }

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullServiceTaskDeliveryTest.kt
@@ -55,6 +55,7 @@ internal class PullServiceTaskDeliveryTest {
   private val callableCaptor = argumentCaptor<Callable<Unit>>()
 
   private val taskInformationCaptor = argumentCaptor<TaskInformation>()
+  private val failureDtoCaptor = argumentCaptor<ExternalTaskFailureDto>()
 
   private val durationCaptor = argumentCaptor<Duration>()
 
@@ -352,27 +353,51 @@ internal class PullServiceTaskDeliveryTest {
   fun `taskActionHandlerCallable handles exceptions`() {
     val lockedTask = mockLockedExternalTaskDto("1")
     val activeSubscription = mockTaskSubscriptionHandle()
-
-    val exception = RuntimeException("Something went wrong")
-    doThrow(exception)
-      .whenever(subscriptionRepository)
-      .activateSubscriptionForTask("1", activeSubscription)
-
-    val callable = taskDelivery.createTaskActionHandlerCallable(lockedTask, activeSubscription)
-    callable.call()
-
-    verifyNoInteractions(valueMapper)
-    verify(metrics).incrementFailedTasksCounter(lockedTask.topicName!!)
-    verify(externalTaskApiClient).handleFailure(
-      lockedTask.id,
-      ExternalTaskFailureDto().apply {
-        workerId = this@PullServiceTaskDeliveryTest.workerId
-        retries = 0
-        retryTimeout = 10_000
-        errorDetails = exception.stackTraceToString()
-        errorMessage = exception.message
+    val state = mutableMapOf<String, TaskInformation>()
+    val terminated = mutableListOf<TaskInformation>()
+    val variables = Variables.createVariables()
+    lockedTask.variables!!.entries.forEach {
+      variables[it.key] = it.value.value
+    }
+    val subscription = activeSubscription.copy(
+      action = { taskInformation, _ ->
+        state[taskInformation.taskId] = taskInformation
+        throw RuntimeException("Something went wrong")
+      },
+      termination = { taskInformation ->
+        state.remove(taskInformation.taskId)
+        terminated.add(taskInformation)
       }
     )
+
+    doAnswer {
+      val taskId = it.getArgument<String>(0)
+      val subscriptionHandle = it.getArgument<TaskSubscriptionHandle>(1)
+      whenever(subscriptionRepository.deactivateSubscriptionForTask(taskId)).thenReturn(subscriptionHandle)
+      Unit
+    }.whenever(subscriptionRepository).activateSubscriptionForTask("1", subscription)
+    doReturn(variables)
+      .whenever(valueMapper)
+      .mapDtos(lockedTask.variables!!)
+    doReturn(mockTaskInformation("1"))
+      .whenever(taskDelivery)
+      .toTaskInformation(lockedTask)
+
+    val callable = taskDelivery.createTaskActionHandlerCallable(lockedTask, subscription)
+    callable.call()
+
+    assertTrue(state.isEmpty())
+    assertEquals(1, terminated.size)
+    assertEquals(TaskInformation.DELETE, terminated.single().meta[REASON])
+    verify(metrics).incrementFailedTasksCounter(lockedTask.topicName!!)
+    verify(externalTaskApiClient).handleFailure(eq(lockedTask.id), failureDtoCaptor.capture())
+    val failureDto = failureDtoCaptor.singleValue
+    assertEquals(workerId, failureDto.workerId)
+    assertEquals(0, failureDto.retries)
+    assertEquals(10_000, failureDto.retryTimeout)
+    assertEquals("Something went wrong", failureDto.errorMessage)
+    assertTrue(failureDto.errorDetails?.contains("RuntimeException") == true)
+    verify(subscriptionRepository).deactivateSubscriptionForTask("1")
   }
 
   @Test

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullUserTaskDeliveryTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/pull/PullUserTaskDeliveryTest.kt
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class PullUserTaskDeliveryTest {
 
@@ -160,6 +161,36 @@ internal class PullUserTaskDeliveryTest {
 
     // then
     assertThat(deliveredDirectly).isEmpty()
+  }
+
+  @Test
+  fun `failed downstream handler does not leak tasks into user task support`() {
+    val leakingTaskCount = 70
+    val firstRefreshTasks = tasks.take(leakingTaskCount)
+    val userTaskSupport = UserTaskSupport()
+    val terminatedTasks = ConcurrentHashMap<String, String>()
+    val thrownTasks = AtomicInteger()
+
+    whenever(taskApiClient.queryTasks(any(), any(), any()))
+      .thenReturn(ResponseEntity.ok(firstRefreshTasks), ResponseEntity.ok(emptyList()))
+
+    userTaskSupport.subscribe(taskSubscriptionApi = TaskSubscriptionApiImpl(subscriptionRepository), restrictions = mapOf(), payloadDescription = null)
+    userTaskSupport.addHandler { taskInformation, _ ->
+      thrownTasks.incrementAndGet()
+      throw IllegalStateException("boom for ${taskInformation.taskId}")
+    }
+    userTaskSupport.addTerminationHandler { taskInformation ->
+      terminatedTasks[taskInformation.taskId] = taskInformation.taskId
+    }
+
+    embeddedPullUserTaskDelivery.refresh()
+    repeat(3) {
+      embeddedPullUserTaskDelivery.refresh()
+    }
+
+    assertThat(thrownTasks.get()).isEqualTo(leakingTaskCount)
+    assertThat(userTaskSupport.getAllTasks()).isEmpty()
+    assertThat(terminatedTasks).hasSize(leakingTaskCount)
   }
 
   private fun randomTask() = TaskWithAttachmentAndCommentDto()

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingServiceTaskDeliveryTest.kt
@@ -1,19 +1,31 @@
 package dev.bpmcrafters.processengineapi.adapter.c7.remote.task.delivery.subscribe
 
 import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.task.TaskInformation
 import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
 import dev.bpmcrafters.processengineapi.task.TaskType
 import org.assertj.core.api.Assertions.assertThat
+import org.camunda.bpm.client.ExternalTaskClient
+import org.camunda.bpm.client.task.ExternalTaskHandler
 import org.camunda.bpm.client.task.ExternalTask
+import org.camunda.bpm.client.task.ExternalTaskService
+import org.camunda.bpm.client.topic.TopicSubscriptionBuilder
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class SubscribingServiceTaskDeliveryTest {
 
+  private val externalTaskClient: ExternalTaskClient = mock()
+  private val subscriptionRepository = mock<dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository>()
   private val taskDelivery = SubscribingServiceTaskDelivery(
-    externalTaskClient = mock(),
-    subscriptionRepository = mock(),
+    externalTaskClient = externalTaskClient,
+    subscriptionRepository = subscriptionRepository,
     lockDurationInSeconds = 30,
     retryTimeoutInSeconds = 60,
     retries = 3
@@ -53,5 +65,52 @@ internal class SubscribingServiceTaskDeliveryTest {
     with(taskDelivery) {
       assertThat(subscription.matches(externalTask)).isFalse()
     }
+  }
+
+  @Test
+  fun `subscribe cleans up local state when handler throws`() {
+    val state = mutableMapOf<String, TaskInformation>()
+    val terminated = mutableListOf<TaskInformation>()
+    val taskHandler = AtomicReference<ExternalTaskHandler>()
+    val builder = mock<TopicSubscriptionBuilder>()
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      restrictions = mapOf(),
+      taskDescriptionKey = "topic",
+      payloadDescription = null,
+      action = { taskInformation, _ ->
+        state[taskInformation.taskId] = taskInformation
+        throw RuntimeException("boom")
+      },
+      termination = { taskInformation ->
+        state.remove(taskInformation.taskId)
+        terminated.add(taskInformation)
+      }
+    )
+    val externalTask = mock<ExternalTask>()
+    val externalTaskService = mock<ExternalTaskService>()
+
+    whenever(subscriptionRepository.getTaskSubscriptions()).thenReturn(listOf(subscription))
+    whenever(externalTaskClient.subscribe("topic")).thenReturn(builder)
+    whenever(builder.lockDuration(any())).thenReturn(builder)
+    whenever(builder.handler(any())).thenAnswer {
+      taskHandler.set(it.getArgument(0))
+      builder
+    }
+    whenever(builder.open()).thenReturn(mock())
+    whenever(externalTask.topicName).thenReturn("topic")
+    whenever(externalTask.id).thenReturn("1")
+    whenever(externalTask.retries).thenReturn(2)
+    whenever(externalTask.allVariables).thenReturn(mapOf())
+    whenever(subscriptionRepository.deactivateSubscriptionForTask("1")).thenReturn(subscription)
+
+    taskDelivery.subscribe()
+    taskHandler.get().execute(externalTask, externalTaskService)
+
+    assertTrue(state.isEmpty())
+    assertEquals(1, terminated.size)
+    assertEquals(TaskInformation.DELETE, terminated.single().meta[TaskInformation.REASON])
+    verify(externalTaskService).handleFailure("1", "Error delivering external task", "boom", 1, 60_000)
+    verify(subscriptionRepository).deactivateSubscriptionForTask("1")
   }
 }


### PR DESCRIPTION
The constant leak was reproducible, and it was not caused by scheduler overlap. The new regression test models exactly this case: one `UserTaskSupport` subscription, tasks delivered once, a downstream handler throws after `UserTaskSupport` has
  already stored them, then later refreshes see an empty engine. Before the fix, those tasks stayed in UserTaskSupport forever because delivery only deactivated the repository mapping and never invoked termination.

On delivery failure they now remove the local delivered-task cache, deactivate the subscription mapping, and invoke the termination handler so
  `UserTaskSupport` cleans itself up. I also moved stale-snapshot removal into finally, so an exception while processing an already-known task no longer makes the same refresh falsely treat it as deleted later, and I serialized `refresh()` to harden
  against accidental overlap. The remote variant also had a wrong monitor when mutating deliveredTaskIds; that is corrected.
  
The embedded implementation had the same bug before the fix: if UserTaskSupport stored the task first and a later handler threw the strategy only deactivated the repository entry and did not invoke termination. That meant the task could stay in `UserTaskSupport` permanently.  
  
- fix #211