### PR TITLE
Fix timeout unit from seconds to milliseconds

### DIFF
--- a/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/C7ServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/C7ServiceTaskCompletionApiImpl.kt
@@ -6,7 +6,6 @@ import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
 import dev.bpmcrafters.processengineapi.task.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.ExternalTaskService
-import java.time.temporal.ChronoUnit
 import java.util.concurrent.CompletableFuture
 
 private val logger = KotlinLogging.logger {}
@@ -61,13 +60,14 @@ class C7ServiceTaskCompletionApiImpl(
     logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-010: failing service task ${cmd.taskId}." }
     return commandExecutor.execute {
       val (retries, retryTimeoutInSeconds) = failureRetrySupplier.apply(cmd.taskId)
+      val retryTimeoutInMillis = cmd.retryBackoff?.toMillis() ?: retryTimeoutInSeconds * 1000
       externalTaskService.handleFailure(
         cmd.taskId,
         workerId,
         cmd.reason,
         cmd.errorDetails,
         cmd.retryCount ?: retries,
-        cmd.retryBackoff?.get(ChronoUnit.SECONDS) ?: retryTimeoutInSeconds
+        retryTimeoutInMillis
       )
       subscriptionRepository.deactivateSubscriptionForTask(cmd.taskId)?.apply {
         termination.accept(TaskInformation(cmd.taskId, emptyMap()).withReason(TaskInformation.COMPLETE))

--- a/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/C7ServiceTaskCompletionApiImplTest.kt
+++ b/engine-adapter/c7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/C7ServiceTaskCompletionApiImplTest.kt
@@ -1,0 +1,48 @@
+package dev.bpmcrafters.processengineapi.adapter.c7.embedded.task.completion
+
+import dev.bpmcrafters.processengineapi.adapter.c7.embedded.shared.EngineCommandExecutor
+import dev.bpmcrafters.processengineapi.task.FailTaskCmd
+import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
+import org.camunda.bpm.engine.ExternalTaskService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.time.Duration
+import java.util.concurrent.Executor
+
+internal class C7ServiceTaskCompletionApiImplTest {
+
+  private val externalTaskService = mock<ExternalTaskService>()
+  private val completionApi = C7ServiceTaskCompletionApiImpl(
+    workerId = "worker",
+    externalTaskService = externalTaskService,
+    subscriptionRepository = mock<SubscriptionRepository>(),
+    failureRetrySupplier = FixedFailureRetrySupplier,
+    commandExecutor = EngineCommandExecutor(Executor { it.run() })
+  )
+
+  @Test
+  fun `failTask passes provided retryBackoff in milliseconds to camunda engine`() {
+    completionApi.failTask(
+      FailTaskCmd("task", "reason", "details", 2, Duration.ofSeconds(3))
+    ).join()
+
+    verify(externalTaskService).handleFailure("task", "worker", "reason", "details", 2, 3_000)
+  }
+
+  @Test
+  fun `failTask converts supplier retry timeout seconds to milliseconds`() {
+    completionApi.failTask(
+      FailTaskCmd("task", "reason", "details", null, null)
+    ).join()
+
+    verify(externalTaskService).handleFailure("task", "worker", "reason", "details", 4, 7_000)
+  }
+
+  private object FixedFailureRetrySupplier : FailureRetrySupplier {
+    override fun apply(taskId: String) = FailureRetrySupplier.FailureRetry(
+      retryCount = 4,
+      retryTimeout = 7
+    )
+  }
+}

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImpl.kt
@@ -9,7 +9,6 @@ import org.camunda.community.rest.client.model.CompleteExternalTaskDto
 import org.camunda.community.rest.client.model.ExternalTaskBpmnError
 import org.camunda.community.rest.client.model.ExternalTaskFailureDto
 import org.camunda.community.rest.variables.ValueMapper
-import java.time.temporal.ChronoUnit
 import java.util.concurrent.CompletableFuture
 
 private val logger = KotlinLogging.logger {}
@@ -63,12 +62,13 @@ class FeignServiceTaskCompletionApiImpl(
   override fun failTask(cmd: FailTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-010: failing service task ${cmd.taskId}." }
     val (retries, retryTimeoutInSeconds) = failureRetrySupplier.apply(cmd.taskId)
+    val retryTimeoutInMillis = cmd.retryBackoff?.toMillis() ?: retryTimeoutInSeconds * 1000
     externalTaskApiClient.handleFailure(
       cmd.taskId,
       ExternalTaskFailureDto().apply {
         this.workerId = this@FeignServiceTaskCompletionApiImpl.workerId
         this.retries = cmd.retryCount ?: retries
-        this.retryTimeout = cmd.retryBackoff?.get(ChronoUnit.SECONDS) ?: retryTimeoutInSeconds
+        this.retryTimeout = retryTimeoutInMillis
         this.errorDetails = cmd.errorDetails
         this.errorMessage = cmd.reason
       }

--- a/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImpl.kt
+++ b/engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImpl.kt
@@ -4,7 +4,6 @@ import dev.bpmcrafters.processengineapi.Empty
 import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
 import dev.bpmcrafters.processengineapi.task.*
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.time.temporal.ChronoUnit
 import java.util.concurrent.CompletableFuture
 import org.camunda.bpm.client.task.ExternalTaskService as ClientExternalTaskService
 
@@ -59,13 +58,14 @@ class OfficialClientServiceTaskCompletionApiImpl(
   override fun failTask(cmd: FailTaskCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-C7-REMOTE-010: failing service task ${cmd.taskId}." }
     val (retries, retryTimeoutInSeconds) = failureRetrySupplier.apply(cmd.taskId)
+    val retryTimeoutInMillis = cmd.retryBackoff?.toMillis() ?: retryTimeoutInSeconds * 1000
     externalTaskService
       .handleFailure(
         cmd.taskId,
         cmd.reason,
         cmd.errorDetails,
         cmd.retryCount ?: retries,
-        cmd.retryBackoff?.get(ChronoUnit.SECONDS) ?: retryTimeoutInSeconds
+        retryTimeoutInMillis
       )
     subscriptionRepository.deactivateSubscriptionForTask(cmd.taskId)?.apply {
       termination.accept(

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImplTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImplTest.kt
@@ -1,0 +1,55 @@
+package dev.bpmcrafters.processengineapi.adapter.c7.remote.task.completion
+
+import dev.bpmcrafters.processengineapi.task.FailTaskCmd
+import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
+import org.camunda.community.rest.client.api.ExternalTaskApiClient
+import org.camunda.community.rest.client.model.ExternalTaskFailureDto
+import org.camunda.community.rest.variables.ValueMapper
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.time.Duration
+import kotlin.test.assertEquals
+
+internal class FeignServiceTaskCompletionApiImplTest {
+
+  private val externalTaskApiClient = mock<ExternalTaskApiClient>()
+  private val failureDtoCaptor = argumentCaptor<ExternalTaskFailureDto>()
+  private val completionApi = FeignServiceTaskCompletionApiImpl(
+    workerId = "worker",
+    externalTaskApiClient = externalTaskApiClient,
+    subscriptionRepository = mock<SubscriptionRepository>(),
+    failureRetrySupplier = FixedFailureRetrySupplier,
+    valueMapper = mock<ValueMapper>()
+  )
+
+  @Test
+  fun `failTask writes provided retryBackoff in milliseconds to failure dto`() {
+    completionApi.failTask(
+      FailTaskCmd("task", "reason", "details", 2, Duration.ofSeconds(3))
+    ).join()
+
+    verify(externalTaskApiClient).handleFailure(eq("task"), failureDtoCaptor.capture())
+    assertEquals(3_000, failureDtoCaptor.firstValue.retryTimeout)
+  }
+
+  @Test
+  fun `failTask converts supplier retry timeout seconds to milliseconds in failure dto`() {
+    completionApi.failTask(
+      FailTaskCmd("task", "reason", "details", null, null)
+    ).join()
+
+    verify(externalTaskApiClient).handleFailure(eq("task"), failureDtoCaptor.capture())
+    assertEquals(4, failureDtoCaptor.firstValue.retries)
+    assertEquals(7_000, failureDtoCaptor.firstValue.retryTimeout)
+  }
+
+  private object FixedFailureRetrySupplier : FailureRetrySupplier {
+    override fun apply(taskId: String) = FailureRetrySupplier.FailureRetry(
+      retryCount = 4,
+      retryTimeout = 7
+    )
+  }
+}

--- a/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImplTest.kt
+++ b/engine-adapter/c7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImplTest.kt
@@ -1,0 +1,44 @@
+package dev.bpmcrafters.processengineapi.adapter.c7.remote.task.completion
+
+import dev.bpmcrafters.processengineapi.task.FailTaskCmd
+import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.time.Duration
+import org.camunda.bpm.client.task.ExternalTaskService as ClientExternalTaskService
+
+internal class OfficialClientServiceTaskCompletionApiImplTest {
+
+  private val externalTaskService = mock<ClientExternalTaskService>()
+  private val completionApi = OfficialClientServiceTaskCompletionApiImpl(
+    externalTaskService = externalTaskService,
+    subscriptionRepository = mock<SubscriptionRepository>(),
+    failureRetrySupplier = FixedFailureRetrySupplier
+  )
+
+  @Test
+  fun `failTask passes provided retryBackoff in milliseconds to official client`() {
+    completionApi.failTask(
+      FailTaskCmd("task", "reason", "details", 2, Duration.ofSeconds(3))
+    ).join()
+
+    verify(externalTaskService).handleFailure("task", "reason", "details", 2, 3_000)
+  }
+
+  @Test
+  fun `failTask converts supplier retry timeout seconds to milliseconds for official client`() {
+    completionApi.failTask(
+      FailTaskCmd("task", "reason", "details", null, null)
+    ).join()
+
+    verify(externalTaskService).handleFailure("task", "reason", "details", 4, 7_000)
+  }
+
+  private object FixedFailureRetrySupplier : FailureRetrySupplier {
+    override fun apply(taskId: String) = FailureRetrySupplier.FailureRetry(
+      retryCount = 4,
+      retryTimeout = 7
+    )
+  }
+}


### PR DESCRIPTION
Updated the external-task failure completion paths to pass retry timeouts in milliseconds in all three affected implementations: engine-adapter/c7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/completion/
  C7ServiceTaskCompletionApiImpl.kt:59, engine-adapter/c7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/completion/FeignServiceTaskCompletionApiImpl.kt:62, and engine-adapter/c7-remote-core/src/main/kotlin/dev/
  bpmcrafters/processengineapi/adapter/c7/remote/task/completion/OfficialClientServiceTaskCompletionApiImpl.kt:58. Explicit retryBackoff now uses toMillis(), and the fallback retryTimeoutInSeconds path is multiplied by 1000.
  
- fix #210